### PR TITLE
WalletConnect WrongNetwork

### DIFF
--- a/components/WalletConnect.tsx
+++ b/components/WalletConnect.tsx
@@ -1,22 +1,22 @@
 import { useEffect } from "react";
-import { useIsWrongNetwork } from "@hooks";
+import { useIsEthereumMainnet } from "@hooks";
 import { useWeb3Modal } from "@web3modal/wagmi/react";
 
 export default function WalletConnect() {
   const { open } = useWeb3Modal();
-  const isWrongNetwork = useIsWrongNetwork();
+  const isEthereumMainnet = useIsEthereumMainnet();
 
   useEffect(() => {
-    console.log(`Is Ethereum Mainnet: ${!isWrongNetwork}`);
-    if (!isWrongNetwork) return;
+    console.log(`Is Ethereum Mainnet: ${isEthereumMainnet}`);
+    if (isEthereumMainnet) return;
     else open({ view: "Networks" });
-  }, [isWrongNetwork]);
+  }, [isEthereumMainnet, open]);
 
   return (
     // removed: flex-col items-end sm:flex-row sm:
     <div className="flex sm:flex-row items-center gap-4">
       <div className="flex items-center gap-2 font-bold">
-        <w3m-network-button disabled={isWrongNetwork} />
+        <w3m-network-button disabled={isEthereumMainnet ? true : undefined} />
         <w3m-button />
       </div>
     </div>

--- a/components/WalletConnect.tsx
+++ b/components/WalletConnect.tsx
@@ -1,7 +1,22 @@
+import { useEffect } from "react";
+import { useIsWrongNetwork } from "@hooks";
+import { useWeb3Modal } from "@web3modal/wagmi/react";
+
 export default function WalletConnect() {
+  const { open } = useWeb3Modal();
+  const isWrongNetwork = useIsWrongNetwork();
+
+  useEffect(() => {
+    console.log(`Is Ethereum Mainnet: ${!isWrongNetwork}`);
+    if (!isWrongNetwork) return;
+    else open({ view: "Networks" });
+  }, [isWrongNetwork]);
+
   return (
-    <div className="flex items-center gap-4">
+    // removed: flex-col items-end sm:flex-row sm:
+    <div className="flex sm:flex-row items-center gap-4">
       <div className="flex items-center gap-2 font-bold">
+        <w3m-network-button disabled={isWrongNetwork} />
         <w3m-button />
       </div>
     </div>

--- a/components/WalletConnect.tsx
+++ b/components/WalletConnect.tsx
@@ -13,10 +13,9 @@ export default function WalletConnect() {
   }, [isEthereumMainnet, open]);
 
   return (
-    // removed: flex-col items-end sm:flex-row sm:
     <div className="flex sm:flex-row items-center gap-4">
       <div className="flex items-center gap-2 font-bold">
-        <w3m-network-button disabled={isEthereumMainnet ? true : undefined} />
+        {isEthereumMainnet ? null : <w3m-network-button />}
         <w3m-button />
       </div>
     </div>

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -25,4 +25,4 @@ export * from "./useZchfPrice";
 export * from "./useTokenData";
 export * from "./useUserBalance";
 export * from "./useActiveUsersQuery";
-export * from "./useIsWrongNetwork";
+export * from "./useNetworkStats";

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -25,3 +25,4 @@ export * from "./useZchfPrice";
 export * from "./useTokenData";
 export * from "./useUserBalance";
 export * from "./useActiveUsersQuery";
+export * from "./useIsWrongNetwork";

--- a/hooks/useIsWrongNetwork.ts
+++ b/hooks/useIsWrongNetwork.ts
@@ -1,6 +1,0 @@
-import { mainnet, useNetwork } from "wagmi";
-
-export const useIsWrongNetwork = () => {
-  const network = useNetwork();
-  return network.chain && network.chain.id != mainnet.id;
-};

--- a/hooks/useIsWrongNetwork.ts
+++ b/hooks/useIsWrongNetwork.ts
@@ -1,0 +1,6 @@
+import { mainnet, useNetwork } from "wagmi";
+
+export const useIsWrongNetwork = () => {
+  const network = useNetwork();
+  return network.chain && network.chain.id != mainnet.id;
+};

--- a/hooks/useNetworkStats.ts
+++ b/hooks/useNetworkStats.ts
@@ -1,0 +1,6 @@
+import { mainnet, useNetwork } from "wagmi";
+
+export const useIsEthereumMainnet = () => {
+  const network = useNetwork();
+  return network.chain && network.chain.id === mainnet.id;
+};


### PR DESCRIPTION
based on PR#32 
https://github.com/Frankencoin-ZCHF/frankencoin-dapp/pull/32

- fixes not connected to ethereum mainnet
- opens WalletConnet (network view) to select accepted networks
- shows WalletConnect connected chain
- disables WalletConnect "Change Network Button" when connected to ethereum mainnet

Tested with MetaMask. Ok.
--> MetaMask pops open with "Allow this site to switch the network?"