### PR TITLE
URI_APP_MAINNET to "app."

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -5,7 +5,7 @@ import { mainnet } from "wagmi";
 
 // URIs
 export const URI_APP_LOCALHOST = "http://localhost:3000";
-export const URI_APP_MAINNET = "https://frankencoin.com";
+export const URI_APP_MAINNET = "https://app.frankencoin.com";
 export const URI_APP_MAINDEV = "https://devapp.frankencoin.com";
 export const URI_APP_DEVELOPER = "https://dapp.frankencoin.domain.com";
 


### PR DESCRIPTION
# Requirement before push
Domain redirect as @TaprootFreak proposed:
```
www -> frankencoin.com
app -> railway instance of App
```

If CORS error in console.log or app doesn't load any data, means it can't reach nextjs api endpoints (redirect or app.config wrong) or DNS needs some time to update