### PR TITLE
feat: removal of expired swap bridge

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -30,11 +30,6 @@ export function NavItems() {
 			<li>
 				<NavButton to="/governance" name="Governance" />
 			</li>
-			{isMainet && (
-				<li>
-					<NavButton to="/swap" name="Swap" />
-				</li>
-			)}
 		</>
 	);
 }


### PR DESCRIPTION
- Stablecoin Bridge XCHF expired
- removes "Swap" from the Navigation Bar