### PR TITLE
fix: exclude reserve portion from "getMintAmount", use 36 digits adjusted by collateralDecimals

### DIFF
--- a/components/PageMypositions/PositionRollerRow.tsx
+++ b/components/PageMypositions/PositionRollerRow.tsx
@@ -53,11 +53,11 @@ export default function PositionRollerRow({ headers, tab, source, target }: Prop
 				chainId: mainnet.id,
 				abi: PositionV2ABI,
 				functionName: "getMintAmount",
-				args: [BigInt(source.minted)],
+				args: [(BigInt(source.minted) * BigInt(1000000 - source.reserveContribution)) / BigInt("1000000")],
 			});
 
 			const maxMintByCollateral =
-				(BigInt(source.collateralBalance) * BigInt(target.price)) / BigInt(10 ** (18 - target.collateralDecimals));
+				(BigInt(source.collateralBalance) * BigInt(target.price)) / BigInt(10 ** (36 - target.collateralDecimals));
 
 			if (mintAmount <= maxMintByCollateral) {
 				setMissingFunds(0n);


### PR DESCRIPTION
# Issue with Roller

https://www.tdly.co/shared/simulation/140dabeb-727c-4d26-ad59-4afe0078d9e5

## Source

https://app.frankencoin.com/mypositions/0x5CE44886Dee40EDdbCa1EBEaeb06e079f9e2077F

## Owner

https://etherscan.io/address/0xe04415142De52C30bC014b74c43a65aDB41759b5

## Target

https://app.frankencoin.com/monitoring/0x03299CA7Df3f594D24Bb66565919D95D9347Bbb9

# Fixed in App

Major issue was to use the full "minted" amount of the source position to calculate the target position "getMintAmount". Excluded reserve portion to get the correct mint amount. 

Minor issue was to adjust the missing amount correctly by 36 digits minus the collateral decimals

<img width="1153" height="306" alt="Screenshot 2025-12-30 at 11 21 00 AM" src="https://github.com/user-attachments/assets/a479dfbe-1391-4d5f-bff2-1b0d62264614" />

# Fixed in sumulation

- fund owner wallet with 110 ZCHF 
- fully roll from source to target

<img width="1573" height="898" alt="Screenshot 2025-12-30 at 11 19 30 AM" src="https://github.com/user-attachments/assets/65c70c9c-4d2c-4ac6-854b-8d70565f60c6" />

