### PR TITLE
feat: add soft limit warnings when proposing collateral

### DIFF
--- a/components/Input/NormalInput.tsx
+++ b/components/Input/NormalInput.tsx
@@ -7,6 +7,7 @@ interface Props {
 	value?: string;
 	onChange?: (value: string) => void;
 	error?: string;
+	warning?: string;
 
 	symbol: string;
 	digit?: bigint | number;
@@ -23,6 +24,7 @@ export default function NormalInput({
 	value = "",
 	onChange,
 	error,
+	warning,
 	symbol,
 	digit = 18,
 	output,
@@ -74,7 +76,13 @@ export default function NormalInput({
 				</div>
 			</div>
 
-			<div className="flex my-2 px-3.5 text-text-warning">{error}</div>
+			{error ? (
+				<div className="flex my-2 px-3.5 text-text-warning">{error}</div>
+			) : warning ? (
+				<div className="flex my-2 px-3.5 text-amber-500">{warning}</div>
+			) : (
+				<div className="flex my-2 px-3.5">{note}</div>
+			)}
 		</div>
 	);
 }

--- a/components/Input/TokenInput.tsx
+++ b/components/Input/TokenInput.tsx
@@ -28,6 +28,7 @@ interface Props {
 	autoFocus?: boolean;
 	disabled?: boolean;
 	error?: string;
+	warning?: string;
 }
 
 export default function TokenInput({
@@ -52,6 +53,7 @@ export default function TokenInput({
 	onMax = () => {},
 	onReset = () => {},
 	error,
+	warning,
 }: Props) {
 	const inputRef = useRef<HTMLInputElement>(null);
 
@@ -158,7 +160,13 @@ export default function TokenInput({
 				) : null}
 			</div>
 
-			{error ? <div className="flex my-2 px-3.5 text-text-warning">{error}</div> : <div className="flex my-2 px-3.5">{note}</div>}
+			{error ? (
+				<div className="flex my-2 px-3.5 text-text-warning">{error}</div>
+			) : warning ? (
+				<div className="flex my-2 px-3.5 text-amber-500">{warning}</div>
+			) : (
+				<div className="flex my-2 px-3.5">{note}</div>
+			)}
 		</div>
 	);
 }

--- a/pages/mint/create.tsx
+++ b/pages/mint/create.tsx
@@ -48,6 +48,12 @@ export default function PositionCreate({}) {
 	const [liqPriceError, setLiqPriceError] = useState("");
 	const [bufferError, setBufferError] = useState("");
 	const [durationError, setDurationError] = useState("");
+
+	// Soft limit warnings (non-blocking)
+	const [limitWarning, setLimitWarning] = useState("");
+	const [bufferWarning, setBufferWarning] = useState("");
+	const [durationWarning, setDurationWarning] = useState("");
+	const [minCollWarning, setMinCollWarning] = useState("");
 	const [isConfirming, setIsConfirming] = useState("");
 	const [isInit, setIsInit] = useState(false);
 
@@ -164,6 +170,13 @@ export default function PositionCreate({}) {
 	const onChangeLimitAmount = (value: string) => {
 		const valueBigInt = BigInt(value);
 		setLimitAmount(valueBigInt);
+
+		// Soft limit: warn if limit exceeds 2.5 million ZCHF
+		if (valueBigInt > parseUnits("2500000", 18)) {
+			setLimitWarning("Recommended: limit should not exceed 2.5 million ZCHF");
+		} else {
+			setLimitWarning("");
+		}
 	};
 
 	const onChangeCollateralAddress = (addr: string) => {
@@ -206,12 +219,21 @@ export default function PositionCreate({}) {
 	};
 
 	function checkCollateralAmount(coll: bigint, price: bigint) {
-		if (coll * price < parseUnits("5000", 36)) {
+		const collValue = coll * price;
+		if (collValue < parseUnits("5000", 36)) {
 			setLiqPriceError("The liquidation value of the collateral must be at least 5000 ZCHF");
 			setMinCollAmountError("The collateral must be worth at least 5000 ZCHF");
+			setMinCollWarning("");
 		} else {
 			setLiqPriceError("");
 			setMinCollAmountError("");
+
+			// Soft limit: warn if minimum collateral is below 7500 ZCHF
+			if (collValue < parseUnits("7500", 36)) {
+				setMinCollWarning("Recommended: minimum collateral should be worth at least 7500 ZCHF");
+			} else {
+				setMinCollWarning("");
+			}
 		}
 	}
 
@@ -225,6 +247,13 @@ export default function PositionCreate({}) {
 		} else {
 			setBufferError("");
 		}
+
+		// Soft limit: warn if reserve ratio is below 20%
+		if (valueBigInt < 200_000n && valueBigInt >= 100_000n) {
+			setBufferWarning("Recommended: reserve ratio should be at least 20%");
+		} else {
+			setBufferWarning("");
+		}
 	};
 
 	const onChangeAuctionDuration = (value: string) => {
@@ -234,6 +263,13 @@ export default function PositionCreate({}) {
 			setDurationError("Duration must be at least 12h");
 		} else {
 			setDurationError("");
+		}
+
+		// Soft limit: warn if auction duration is below 24 hours
+		if (valueBigInt < 24n && valueBigInt >= 12n) {
+			setDurationWarning("Recommended: auction duration should be at least 24 hours");
+		} else {
+			setDurationWarning("");
 		}
 	};
 
@@ -452,6 +488,7 @@ export default function PositionCreate({}) {
 							label="Minimum Collateral"
 							symbol={collTokenData.symbol}
 							error={minCollAmountError}
+							warning={minCollWarning}
 							hideMaxLabel
 							value={minCollAmount.toString()}
 							onChange={onChangeMinCollAmount}
@@ -477,6 +514,7 @@ export default function PositionCreate({}) {
 							hideMaxLabel
 							symbol="ZCHF"
 							error={limitAmountError}
+							warning={limitWarning}
 							// min={parseEther("200000")}
 							// max={parseEther("10000000")}
 							// reset={parseEther("1000000")}
@@ -524,6 +562,7 @@ export default function PositionCreate({}) {
 								label="Retained Reserve"
 								symbol="%"
 								error={bufferError}
+								warning={bufferWarning}
 								digit={4}
 								value={buffer.toString()}
 								onChange={onChangeBuffer}
@@ -533,6 +572,7 @@ export default function PositionCreate({}) {
 								label="Auction Duration"
 								symbol="hours"
 								error={durationError}
+								warning={durationWarning}
 								digit={0}
 								value={auctionDuration.toString()}
 								onChange={onChangeAuctionDuration}


### PR DESCRIPTION
Closes #355

Adds soft limit warnings (non-blocking) when proposing collateral:
- **Auction duration**: warns if below 24 hours
- **Minting limit**: warns if above 2.5 million ZCHF
- **Reserve ratio**: warns if below 20%
- **Minimum collateral**: warns if worth below 7500 ZCHF

These warnings appear in amber color to distinguish from hard errors (red) that block submission. Users can still proceed but are informed of recommended values to narrow the attack window.