### PR TITLE
feat: searchable table extensions, monitoring overhaul, and UI polish

### DIFF
--- a/components/AppTitle.tsx
+++ b/components/AppTitle.tsx
@@ -12,10 +12,12 @@ interface Props {
 	url?: string;
 	className?: string;
 	classNameTitle?: string;
+	badge?: string;
+	badgeColor?: string;
 	children?: React.ReactElement | React.ReactElement[];
 }
 
-export default function AppTitle({ title, symbol, icon, url, className, classNameTitle, children }: Props) {
+export default function AppTitle({ title, symbol, icon, url, className, classNameTitle, badge, badgeColor = "bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200", children }: Props) {
 	return (
 		<div className={`${className} pt-6`}>
 			{(symbol || icon || url || title) && (
@@ -24,6 +26,7 @@ export default function AppTitle({ title, symbol, icon, url, className, classNam
 					{icon && <FontAwesomeIcon icon={icon} className="w-8 h-8" />}
 					{url && <Image src={url} width={32} height={32} className="rounded-full" alt="logo" unoptimized />}
 					{title && <span className={`${classNameTitle} font-bold text-2xl text-text-primary`}>{title}</span>}
+					{badge && <span className={`${badgeColor} text-sm font-medium px-2.5 py-0.5 rounded-lg`}>{badge}</span>}
 				</div>
 			)}
 			{children ?? null}

--- a/components/AppTitle.tsx
+++ b/components/AppTitle.tsx
@@ -5,6 +5,11 @@ import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 
 const TokenLogo = dynamic(() => import("./TokenLogo"), { ssr: false });
 
+interface BadgeProps {
+	label: string;
+	className: string;
+}
+
 interface Props {
 	title?: string;
 	symbol?: string;
@@ -14,19 +19,50 @@ interface Props {
 	classNameTitle?: string;
 	badge?: string;
 	badgeColor?: string;
+	badges?: BadgeProps[];
+	subtitle?: string | React.ReactNode;
+	actions?: React.ReactNode;
 	children?: React.ReactElement | React.ReactElement[];
 }
 
-export default function AppTitle({ title, symbol, icon, url, className, classNameTitle, badge, badgeColor = "bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200", children }: Props) {
+export default function AppTitle({
+	title,
+	symbol,
+	icon,
+	url,
+	className,
+	classNameTitle,
+	badge,
+	badgeColor = "bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200",
+	badges,
+	subtitle,
+	actions,
+	children,
+}: Props) {
+	const hasHeader = symbol || icon || url || title;
+
 	return (
 		<div className={`${className} pt-6`}>
-			{(symbol || icon || url || title) && (
-				<div className="flex items-center gap-3">
-					{symbol && <TokenLogo currency={symbol} />}
-					{icon && <FontAwesomeIcon icon={icon} className="w-8 h-8" />}
-					{url && <Image src={url} width={32} height={32} className="rounded-full" alt="logo" unoptimized />}
-					{title && <span className={`${classNameTitle} font-bold text-2xl text-text-primary`}>{title}</span>}
-					{badge && <span className={`${badgeColor} text-sm font-medium px-2.5 py-0.5 rounded-lg`}>{badge}</span>}
+			{(hasHeader || actions) && (
+				<div className={actions ? "flex flex-col md:flex-row md:items-center justify-between gap-3" : undefined}>
+					<div>
+						{hasHeader && (
+							<div className="flex items-center gap-2 flex-wrap">
+								{symbol && <TokenLogo currency={symbol} />}
+								{icon && <FontAwesomeIcon icon={icon} className="w-8 h-8" />}
+								{url && <Image src={url} width={32} height={32} className="rounded-full" alt="logo" unoptimized />}
+								{title && <span className={`${classNameTitle} font-bold text-2xl text-text-primary`}>{title}</span>}
+								{badge && <span className={`${badgeColor} text-sm font-medium px-2.5 py-0.5 rounded-lg`}>{badge}</span>}
+								{badges?.map((b, i) => (
+									<span key={i} className={`text-xs font-semibold px-2 py-0.5 rounded-full ${b.className}`}>
+										{b.label}
+									</span>
+								))}
+							</div>
+						)}
+						{subtitle && <div className="mt-1 text-text-secondary text-sm">{subtitle}</div>}
+					</div>
+					{actions && <div>{actions}</div>}
 				</div>
 			)}
 			{children ?? null}

--- a/components/Input/LiquidationSlider.tsx
+++ b/components/Input/LiquidationSlider.tsx
@@ -23,6 +23,8 @@ interface Props {
 	limit?: bigint;
 	limitDigit?: bigint | number;
 	limitLabel?: string;
+	limitUnit?: string;
+	limitCurrency?: string;
 }
 
 export default function LiquidationSlider({
@@ -47,6 +49,8 @@ export default function LiquidationSlider({
 	limit = 0n,
 	limitDigit = 18n,
 	limitLabel,
+	limitUnit,
+	limitCurrency,
 }: Props) {
 	const valueNum = Number(formatUnits(value, digit));
 	const sliderMinNum = Number(formatUnits(sliderMin, digit));
@@ -134,22 +138,13 @@ export default function LiquidationSlider({
 								<div className="text-text-secondary flex-shrink-0">{limitLabel}</div>
 								<div className="text-text-primary truncate min-w-0 overflow-hidden">
 									{formatCurrency(formatUnits(limit, Number(limitDigit)))}
+									{limitUnit}
+									{limitCurrency && ` ${limitCurrency}`}
 								</div>
 							</>
 						)}
 					</div>
 					<div className="flex flex-row gap-2">
-						{canShowButtons && max != undefined && max !== value && (
-							<div
-								className="text-card-input-max cursor-pointer hover:text-card-input-focus font-extrabold"
-								onClick={() => {
-									onChange(max);
-									onMax();
-								}}
-							>
-								Max
-							</div>
-						)}
 						{canShowButtons && min != undefined && min !== value && min !== max && (
 							<div
 								className="text-card-input-min cursor-pointer hover:text-card-input-focus font-extrabold"
@@ -170,6 +165,17 @@ export default function LiquidationSlider({
 								}}
 							>
 								Reset
+							</div>
+						)}
+						{canShowButtons && max != undefined && max !== value && (
+							<div
+								className="text-card-input-max cursor-pointer hover:text-card-input-focus font-extrabold"
+								onClick={() => {
+									onChange(max);
+									onMax();
+								}}
+							>
+								Max
 							</div>
 						)}
 					</div>

--- a/components/Input/PageTabInput.tsx
+++ b/components/Input/PageTabInput.tsx
@@ -39,7 +39,7 @@ export default function PageTabInput({ tabs, className }: Props) {
 				</div>
 			</div>
 
-			{tabs[active]?.content}
+			<div className="space-y-8">{tabs[active]?.content}</div>
 		</div>
 	);
 }

--- a/components/Input/TokenInput.tsx
+++ b/components/Input/TokenInput.tsx
@@ -18,6 +18,8 @@ interface Props {
 	limit?: bigint;
 	limitDigit?: bigint | number;
 	limitLabel?: string;
+	limitUnit?: string;
+	limitCurrency?: string;
 	output?: string;
 	note?: string;
 	value?: string;
@@ -44,6 +46,8 @@ export default function TokenInput({
 	limit = 0n,
 	limitDigit = 18n,
 	limitLabel,
+	limitUnit,
+	limitCurrency,
 	output,
 	note,
 	value = "",
@@ -116,24 +120,13 @@ export default function TokenInput({
 									<div className="text-text-secondary flex-shrink-0">{limitLabel}</div>
 									<div className="text-text-primary truncate min-w-0 overflow-hidden">
 										{formatCurrency(formatUnits(limit, Number(limitDigit)))}
+										{limitUnit}
+										{limitCurrency && ` ${limitCurrency}`}
 									</div>
 								</div>
 							)}
 						</div>
 
-						{canShowButtons && max != undefined && max != BigInt(value) && (
-							<div
-								className="text-card-input-max cursor-pointer hover:text-card-input-focus font-extrabold"
-								onClick={() => {
-									if (max !== undefined) {
-										onChange(max.toString());
-										onMax();
-									}
-								}}
-							>
-								Max
-							</div>
-						)}
 						{canShowButtons && min != undefined && min != BigInt(value) && min != max && (
 							<div
 								className="text-card-input-min cursor-pointer hover:text-card-input-focus font-extrabold"
@@ -158,6 +151,19 @@ export default function TokenInput({
 								}}
 							>
 								Reset
+							</div>
+						)}
+						{canShowButtons && max != undefined && max != BigInt(value) && (
+							<div
+								className="text-card-input-max cursor-pointer hover:text-card-input-focus font-extrabold"
+								onClick={() => {
+									if (max !== undefined) {
+										onChange(max.toString());
+										onMax();
+									}
+								}}
+							>
+								Max
 							</div>
 						)}
 					</div>

--- a/components/Input/TokenInputChain.tsx
+++ b/components/Input/TokenInputChain.tsx
@@ -20,6 +20,8 @@ interface Props {
 	limit?: bigint;
 	limitDigit?: bigint | number;
 	limitLabel?: string;
+	limitUnit?: string;
+	limitCurrency?: string;
 	output?: string;
 	note?: string;
 	value?: string;
@@ -47,6 +49,8 @@ export default function TokenInputChain({
 	limit = 0n,
 	limitDigit = 18n,
 	limitLabel,
+	limitUnit,
+	limitCurrency,
 	output,
 	note,
 	value = "",
@@ -124,24 +128,13 @@ export default function TokenInputChain({
 									<div className="text-text-secondary flex-shrink-0">{limitLabel}</div>
 									<div className="text-text-primary truncate min-w-0 overflow-hidden">
 										{formatCurrency(formatUnits(limit, Number(limitDigit)))}
+										{limitUnit}
+										{limitCurrency && ` ${limitCurrency}`}
 									</div>
 								</div>
 							)}
 						</div>
 
-						{!disabled && max != undefined && max != BigInt(value) && (
-							<div
-								className="text-card-input-max cursor-pointer hover:text-card-input-focus font-extrabold"
-								onClick={() => {
-									if (max !== undefined) {
-										onChange(max.toString());
-										onMax();
-									}
-								}}
-							>
-								Max
-							</div>
-						)}
 						{!disabled && min != undefined && min != BigInt(value) && min != max && (
 							<div
 								className="text-card-input-min cursor-pointer hover:text-card-input-focus font-extrabold"
@@ -166,6 +159,19 @@ export default function TokenInputChain({
 								}}
 							>
 								Reset
+							</div>
+						)}
+						{!disabled && max != undefined && max != BigInt(value) && (
+							<div
+								className="text-card-input-max cursor-pointer hover:text-card-input-focus font-extrabold"
+								onClick={() => {
+									if (max !== undefined) {
+										onChange(max.toString());
+										onMax();
+									}
+								}}
+							>
+								Max
 							</div>
 						)}
 					</div>

--- a/components/Input/TokenInputSelect.tsx
+++ b/components/Input/TokenInputSelect.tsx
@@ -23,6 +23,8 @@ interface Props {
 	limit?: bigint;
 	limitDigit?: bigint | number;
 	limitLabel?: string;
+	limitUnit?: string;
+	limitCurrency?: string;
 	output?: string | number;
 	note?: string;
 	value?: string;
@@ -48,6 +50,8 @@ export default function TokenInputSelect({
 	limit = 0n,
 	limitDigit = 18n,
 	limitLabel,
+	limitUnit,
+	limitCurrency,
 	output,
 	note,
 	value = "0",
@@ -182,24 +186,13 @@ export default function TokenInputSelect({
 									<div className="text-text-secondary flex-shrink-0">{limitLabel}</div>
 									<div className="text-text-primary truncate min-w-0 overflow-hidden">
 										{formatCurrency(formatUnits(limit, Number(limitDigit)))}
+										{limitUnit}
+										{limitCurrency && ` ${limitCurrency}`}
 									</div>
 								</div>
 							)}
 						</div>
 
-						{!disabled && max != undefined && (
-							<div
-								className="text-card-input-max cursor-pointer hover:text-card-input-focus font-extrabold"
-								onClick={() => {
-									if (max !== undefined) {
-										onChange(max.toString());
-										onMax();
-									}
-								}}
-							>
-								Max
-							</div>
-						)}
 						{!disabled && min != undefined && (
 							<div
 								className="text-card-input-min cursor-pointer hover:text-card-input-focus font-extrabold"
@@ -224,6 +217,19 @@ export default function TokenInputSelect({
 								}}
 							>
 								Reset
+							</div>
+						)}
+						{!disabled && max != undefined && (
+							<div
+								className="text-card-input-max cursor-pointer hover:text-card-input-focus font-extrabold"
+								onClick={() => {
+									if (max !== undefined) {
+										onChange(max.toString());
+										onMax();
+									}
+								}}
+							>
+								Max
 							</div>
 						)}
 					</div>

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -17,7 +17,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 			<Navbar />
 
 			<div className="h-main pt-16">
-				<main className="block mb-16 mx-auto max-w-6xl space-y-8 px-4 md:px-8 2xl:max-w-7xl min-h-content">{children}</main>
+				<main className="block mb-24 mx-auto max-w-6xl space-y-8 px-4 md:px-8 2xl:max-w-7xl min-h-content">{children}</main>
 				<Footer />
 			</div>
 		</div>

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -16,7 +16,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
 			<Navbar />
 
-			<div className="h-main pt-20">
+			<div className="h-main pt-16">
 				<main className="block mb-16 mx-auto max-w-6xl space-y-8 px-4 md:px-8 2xl:max-w-7xl min-h-content">{children}</main>
 				<Footer />
 			</div>

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -16,7 +16,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
 			<Navbar />
 
-			<div className="h-main pt-16">
+			<div className="h-main pt-20">
 				<main className="block mb-24 mx-auto max-w-6xl space-y-8 px-4 md:px-8 2xl:max-w-7xl min-h-content">{children}</main>
 				<Footer />
 			</div>

--- a/components/PageBorrow/BorrowRow.tsx
+++ b/components/PageBorrow/BorrowRow.tsx
@@ -29,13 +29,12 @@ export default function BorrowRow({ headers, tab, position, vchfBridge, hideMyWa
 
 	const interest: number = position.annualInterestPPM / 10 ** 4;
 	const reserve: number = position.reserveContribution / 10 ** 4;
-
 	const price: number = parseInt(position.price) / 10 ** (36 - position.collateralDecimals);
 
 	const expirationStr = new Date(position.expiration * 1000).toDateString().split(" ");
 	const expirationString: string = `${expirationStr[2]} ${expirationStr[1]} ${expirationStr[3]}`;
 
-	const effectiveLTV: number = ((price * (1 - reserve / 100)) / collTokenPrice) * zchfPrice * 100;
+	const nominalLTV: number = (price / collTokenPrice) * zchfPrice * 100;
 	const effectiveInterest: number = interest / (1 - reserve / 100);
 
 	const isPending = position.start * 1000 > Date.now();
@@ -90,7 +89,7 @@ export default function BorrowRow({ headers, tab, position, vchfBridge, hideMyWa
 			</div>
 
 			<div className="flex flex-col gap-2">
-				<div className="col-span-2 text-md">{isVCHF ? "Swap 1:1" : `${formatCurrency(effectiveLTV, 2, 2)}%`}</div>
+				<div className="col-span-2 text-md">{isVCHF ? "Swap 1:1" : `${formatCurrency(nominalLTV, 2, 2)}%`}</div>
 			</div>
 
 			<div className="flex flex-col gap-2">

--- a/components/PageBorrow/BorrowTable.tsx
+++ b/components/PageBorrow/BorrowTable.tsx
@@ -21,7 +21,7 @@ export default function BorrowTable() {
 	const [list, setList] = useState<PositionQueryV2[]>([]);
 	const [searchQuery, setSearchQuery] = useState<string>("");
 	const [activeCategories, setActiveCategories] = useState<string[]>([]);
-	const [inMyWallet, setInMyWallet] = useState<boolean>(true);
+	const [inMyWallet, setInMyWallet] = useState<boolean>(false);
 
 	const { address: walletAddress } = useAccount();
 	const vchfBridge = useSwapVCHFStats();
@@ -181,13 +181,12 @@ function sortPositions(
 		// sort for Collateral
 		sorting.sort((a, b) => a.collateralSymbol.localeCompare(b.collateralSymbol)); // default: increase
 	} else if (tab === headers[1]) {
-		// sort for LTV, LTV = liquidation price * (1 - reserve) / market price
+		// sort for LTV, nominal LTV = liquidation price / market price
 		sorting.sort((a, b) => {
 			const calc = function (p: PositionQueryV2) {
 				const liqPrice: number = parseFloat(formatUnits(BigInt(p.price), 36 - p.collateralDecimals));
-				const reserve: number = p.reserveContribution / 1000000;
 				const price: number = prices[normalizeAddress(p.collateral)].price.chf || 1;
-				return (liqPrice * (1 - reserve)) / price;
+				return liqPrice / price;
 			};
 			return calc(b) - calc(a); // default: decrease
 		});

--- a/components/PageEcoSystem/CollateralAndPositionsOverview.tsx
+++ b/components/PageEcoSystem/CollateralAndPositionsOverview.tsx
@@ -73,8 +73,7 @@ export function calcOverviewStats(listByCollateral: PositionQuery[][], allPositi
 		const collateralPriceInZCHF = Math.round((collateral.price.chf / mint.price.chf) * 100) / 100;
 
 		const worstStatusColors = collateralizedPct < 100 ? "red-300" : collateralizedPct < 120 ? "blue-300" : "green-300";
-		const discussionKey = Object.keys(DISCUSSIONS).find((i) => normalizeAddress(i) === normalizeAddress(collateral.address));
-		const discussionLink = discussionKey ? DISCUSSIONS[discussionKey] : DISCUSSIONS["default"];
+		const discussionLink = DISCUSSIONS[normalizeAddress(collateral.address)] ?? DISCUSSIONS["default"];
 
 		const lockedValue = parseFloat(formatUnits(minted, 18)) * avgCollateral;
 

--- a/components/PageEcoSystem/DebtAllocation.tsx
+++ b/components/PageEcoSystem/DebtAllocation.tsx
@@ -28,14 +28,22 @@ export default function DebtAllocation() {
 	// Aggregate swap bridges
 	byCollateral.set("VCHF", swapBridgeVCHF);
 
-	const mapping = [...byCollateral.keys()]
-		.map((label, idx) => {
-			return {
-				label,
-				value: byCollateral.get(label) ?? 0n,
-			};
-		})
+	const MAX_ITEMS = 10;
+
+	const sorted = [...byCollateral.keys()]
+		.map((label) => ({ label, value: byCollateral.get(label) ?? 0n }))
 		.sort((a, b) => (b.value > a.value ? 1 : -1));
+
+	const mapping =
+		sorted.length > MAX_ITEMS
+			? [
+					...sorted.slice(0, MAX_ITEMS - 1),
+					{
+						label: "Others",
+						value: sorted.slice(MAX_ITEMS - 1).reduce((a, b) => a + b.value, 0n),
+					},
+				]
+			: sorted;
 
 	const labels = mapping.map((m) => m.label);
 	const rawValues = mapping.map((m) => m.value);

--- a/components/PageEcoSystem/DebtAllocation.tsx
+++ b/components/PageEcoSystem/DebtAllocation.tsx
@@ -65,8 +65,6 @@ export default function DebtAllocation() {
 
 	return (
 		<AppCard>
-			<div className="mt-4 text-lg font-bold text-center">Frankencoin by Debt</div>
-
 			<div className="grid md:grid-cols-2 gap-4">
 				<div className="pr-2 my-auto">
 					<ApexChart
@@ -113,7 +111,7 @@ export default function DebtAllocation() {
 					{labels.length == 0 ? <div className="flex justify-center text-text-warning">No data available.</div> : null}
 				</div>
 
-				<div className="mt-8 space-y-1">
+				<div className="my-auto space-y-1">
 					{labels.map((label, idx) => (
 						<div key={`${label}_${idx}`} className="flex justify-between">
 							<div className="text-text-secondary font-semibold" style={{ color: colors[idx % colors.length] }}>

--- a/components/PageEcoSystem/DebtAllocation.tsx
+++ b/components/PageEcoSystem/DebtAllocation.tsx
@@ -3,7 +3,7 @@ import { RootState } from "../../redux/redux.store";
 import AppCard from "../AppCard";
 import { formatUnits } from "viem";
 import dynamic from "next/dynamic";
-import { formatCurrency } from "../../utils/format";
+import { formatCurrency, FormatType } from "../../utils/format";
 import { colors } from "../../utils/constant";
 import { useEffect, useState } from "react";
 import { readContract } from "wagmi/actions";
@@ -119,14 +119,18 @@ export default function DebtAllocation() {
 							<div className="text-text-secondary font-semibold" style={{ color: colors[idx % colors.length] }}>
 								{label} <span className="text-sm">({percentByLabel.get(label)}%)</span>
 							</div>
-							<div className="text-text-secondary font-semibold">{formatCurrency(series[idx].toString(), 2)} ZCHF</div>
+							<div className="text-text-secondary font-semibold">
+								{formatCurrency(series[idx], 2, 2, FormatType.symbol)} ZCHF
+							</div>
 						</div>
 					))}
 					<div className="flex justify-between">
 						<div className="text-text-primary font-semibold mt-2">
 							Total <span className="text-sm">(100%)</span>
 						</div>
-						<div className="text-text-primary font-semibold mt-2">{formatCurrency(formatUnits(total, 18), 2)} ZCHF</div>
+						<div className="text-text-primary font-semibold mt-2">
+							{formatCurrency(formatUnits(total, 18), 2, 2, FormatType.symbol)} ZCHF
+						</div>
 					</div>
 				</div>
 			</div>

--- a/components/PageEcoSystem/FrankencoinAllocation.tsx
+++ b/components/PageEcoSystem/FrankencoinAllocation.tsx
@@ -255,8 +255,6 @@ export default function FrankencoinAllocation() {
 
 	return (
 		<AppCard>
-			<div className="mt-4 text-lg font-bold text-center">Frankencoins by Holder Type</div>
-
 			<div className="grid md:grid-cols-2 gap-4">
 				<div className="pr-2 my-auto">
 					<ApexChart
@@ -303,7 +301,7 @@ export default function FrankencoinAllocation() {
 					{labels.length == 0 ? <div className="flex justify-center text-text-warning">No data available.</div> : null}
 				</div>
 
-				<div className="mt-8 space-y-1">
+				<div className="my-auto space-y-1">
 					{labels.map((label, idx) => (
 						<div key={`${label}_${idx}`} className="flex justify-between">
 							<div className="text-text-secondary font-semibold" style={{ color: colors[idx % colors.length] }}>

--- a/components/PageEcoSystem/FrankencoinAllocation.tsx
+++ b/components/PageEcoSystem/FrankencoinAllocation.tsx
@@ -3,7 +3,7 @@ import { RootState } from "../../redux/redux.store";
 import AppCard from "../AppCard";
 import { formatUnits } from "viem";
 import dynamic from "next/dynamic";
-import { formatCurrency } from "../../utils/format";
+import { formatCurrency, FormatType } from "../../utils/format";
 import { colors } from "../../utils/constant";
 import { useEffect, useState } from "react";
 import { readContract } from "wagmi/actions";
@@ -275,7 +275,7 @@ export default function FrankencoinAllocation() {
 								labels: {
 									show: true,
 									formatter: (value) => {
-										return `${Math.round(value / 100000) / 10} Mio. ZCHF`;
+										return `${Math.round(value / 10000) / 100} Mio. ZCHF`;
 									},
 								},
 							},
@@ -309,14 +309,16 @@ export default function FrankencoinAllocation() {
 							<div className="text-text-secondary font-semibold" style={{ color: colors[idx % colors.length] }}>
 								{label} <span className="text-sm">({percentByLabel.get(label)}%)</span>
 							</div>
-							<div className="text-text-secondary font-semibold">{formatCurrency(series[idx].toString(), 2)} ZCHF</div>
+							<div className="text-text-secondary font-semibold">
+								{formatCurrency(series[idx], 2, 2, FormatType.symbol)} ZCHF
+							</div>
 						</div>
 					))}
 					<div className="flex justify-between">
 						<div className="text-text-primary font-semibold mt-2">
 							Total <span className="text-sm">(100%)</span>
 						</div>
-						<div className="text-text-primary font-semibold mt-2">{formatCurrency(total, 2)} ZCHF</div>
+						<div className="text-text-primary font-semibold mt-2">{formatCurrency(total, 2, 2, FormatType.symbol)} ZCHF</div>
 					</div>
 				</div>
 			</div>

--- a/components/PageEcoSystem/HealthRatio.tsx
+++ b/components/PageEcoSystem/HealthRatio.tsx
@@ -1,4 +1,5 @@
 import AppCard from "../AppCard";
+import AppBox from "../AppBox";
 import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
 import { FRANKENCOIN_API_CLIENT } from "../../app.config";
@@ -38,6 +39,7 @@ export default function HealthRatio() {
 
 	const chartListTimestamp = [...chartData].sort((a, b) => a.timestamp - b.timestamp);
 	const currentEntry = chartListTimestamp.at(-1);
+	const currentPct = (currentEntry?.value || 0) * 100;
 
 	const sortedList = [...chartData].sort((a, b) => a.value - b.value);
 	const sortedLowest = sortedList.at(0);
@@ -48,47 +50,92 @@ export default function HealthRatio() {
 		const d = date.getDate();
 		const m = date.getMonth() + 1;
 		const y = date.getFullYear();
-		const h = date.getHours();
-		return `${d}.${m}.${y} ${h}:00`;
+		const h = String(date.getHours()).padStart(2, "0");
+		const min = String(date.getMinutes()).padStart(2, "0");
+		return `${d}.${m}.${y} ${h}:${min}`;
 	};
+
+	const barPct = Math.min(currentPct / 3, 100);
+	const healthColor = currentPct >= 150 ? "text-green-500" : currentPct >= 100 ? "text-amber-500" : "text-red-500";
+	const barColor = currentPct >= 150 ? "bg-green-500" : currentPct >= 100 ? "bg-amber-500" : "bg-red-500";
 
 	return (
 		<AppCard>
-			<div className="grid md:grid-cols-2 gap-4">
-				<div className="pr-2">
-					<div className="mt-4 text-lg font-bold text-center">Free Supply Collateralization</div>
+			<div className="flex flex-col gap-6">
+				{/* Current value */}
+				<div>
+					<div className={`text-4xl font-bold ${healthColor}`}>{formatCurrency(currentPct, 2)}%</div>
+					<div className="text-text-secondary text-sm mt-1">
+						Current as of {currentEntry ? dateFormatter(currentEntry.timestamp) : "-"}
+					</div>
+				</div>
+
+				{/* Progress bar */}
+				<div>
+					<div className="relative w-full h-3 bg-card-content-primary rounded-full overflow-hidden">
+						<div className={`absolute inset-y-0 left-0 ${barColor} rounded-full`} style={{ width: `${barPct}%` }} />
+					</div>
+					<div className="flex justify-between text-xs text-text-secondary mt-1.5">
+						<span>0%</span>
+						<span>100%</span>
+						<span>200%</span>
+						<span>300%+</span>
+					</div>
+				</div>
+
+				{/* Stats row */}
+				<div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+					<AppBox tight>
+						<div className="text-text-secondary text-xs">Lowest historical</div>
+						<div className="text-text-primary font-bold text-lg">{formatCurrency((sortedLowest?.value || 0) * 100, 2)}%</div>
+						<div className="text-text-secondary text-xs">{sortedLowest ? dateFormatter(sortedLowest.timestamp) : "-"}</div>
+					</AppBox>
+					<AppBox tight>
+						<div className="text-text-secondary text-xs">Highest historical</div>
+						<div className="text-text-primary font-bold text-lg">{formatCurrency((sortedHighest?.value || 0) * 100, 2)}%</div>
+						<div className="text-text-secondary text-xs">{sortedHighest ? dateFormatter(sortedHighest.timestamp) : "-"}</div>
+					</AppBox>
+					<AppBox tight>
+						<div className="text-text-secondary text-xs">Recording since</div>
+						<div className="text-text-primary font-bold text-lg">September 2025</div>
+					</AppBox>
+				</div>
+
+				{/* Chart */}
+				<div className="-mx-4">
 					<ApexChart
-						type="line"
+						type="area"
+						height={200}
 						options={{
-							theme: {
-								monochrome: {
-									enabled: false,
-								},
-							},
-							colors: ["#092f62", "#0F80F0"],
+							colors: [currentPct >= 150 ? "#22c55e" : currentPct >= 100 ? "#f59e0b" : "#ef4444"],
 							stroke: {
-								curve: "linestep",
+								curve: "smooth",
 								width: 2,
 							},
+							fill: {
+								type: "gradient",
+								gradient: {
+									shadeIntensity: 1,
+									opacityFrom: 0.5,
+									opacityTo: 0.02,
+									stops: [0, 100],
+								},
+							},
 							chart: {
-								type: "line",
-								height: 100,
-								dropShadow: {
-									enabled: false,
-								},
-								toolbar: {
-									show: false,
-								},
-								zoom: {
-									enabled: false,
-								},
+								type: "area",
+								height: 200,
+								sparkline: { enabled: false },
+								dropShadow: { enabled: false },
+								toolbar: { show: false },
+								zoom: { enabled: false },
 								background: "0",
 							},
-							dataLabels: {
-								enabled: false,
-							},
+							dataLabels: { enabled: false },
 							grid: {
-								show: false,
+								show: true,
+								borderColor: "rgba(128,128,128,0.1)",
+								strokeDashArray: 4,
+								xaxis: { lines: { show: false } },
 							},
 							xaxis: {
 								type: "datetime",
@@ -96,83 +143,43 @@ export default function HealthRatio() {
 									show: true,
 									formatter: (value) => {
 										const date = new Date(value);
-										const d = date.getDate();
-										const m = date.getMonth() + 1;
-										const y = date.getFullYear();
-										const h = date.getHours();
-										return `${d}.${m}.${y} ${h}:00`;
+										return `${date.getDate()}.${date.getMonth() + 1}.${date.getFullYear()}`;
 									},
 								},
-								axisBorder: {
-									show: false,
-								},
-								axisTicks: {
-									show: false,
-								},
+								axisBorder: { show: false },
+								axisTicks: { show: false },
 							},
 							yaxis: {
 								labels: {
 									show: true,
-									formatter: (value) => {
-										return `${Math.round(value * 10) / 10}%`;
-									},
+									formatter: (value) => `${Math.round(value * 10) / 10}%`,
 								},
-								axisBorder: {
-									show: true,
-								},
-								axisTicks: {
-									show: true,
-								},
+								axisBorder: { show: false },
+								axisTicks: { show: false },
 								min: 0,
-								max: (max) => {
-									return (Math.floor(max / 100) + 1) * 100;
-								},
+								max: (max) => (Math.floor(max / 100) + 1) * 100,
+							},
+							annotations: {
+								yaxis: [
+									{
+										y: 100,
+										borderColor: "#ef4444",
+										strokeDashArray: 4,
+									},
+								],
 							},
 						}}
 						series={[
 							{
 								name: "Collateralization",
-								data: chartListTimestamp.map((entry) => {
-									return [entry.timestamp, Math.round(entry.value * 1000) / 10];
-								}),
-							},
-							{
-								name: "Minimum",
-								data: chartListTimestamp.map((entry) => {
-									return [entry.timestamp, 100];
-								}),
+								data: chartListTimestamp.map((entry) => [entry.timestamp, Math.round(entry.value * 1000) / 10]),
 							},
 						]}
 					/>
 
-					{chartListTimestamp.length == 0 ? (
+					{chartListTimestamp.length === 0 && (
 						<div className="flex justify-center text-text-warning">No data available for selected timeframe.</div>
-					) : null}
-				</div>
-
-				<div className="mt-4 space-y-1">
-					<div className="mb-8 text-lg font-bold text-center">Historic Watermarks</div>
-					<div className="flex justify-between">
-						<div className="text-text-primary font-semibold">
-							<div>Current</div>
-							<span className="text-sm font-normal">{dateFormatter(currentEntry?.timestamp || 0)}</span>
-						</div>
-						<div className="text-text-primary font-semibold">{formatCurrency((currentEntry?.value || 0) * 100, 0)}%</div>
-					</div>
-					<div className="flex justify-between">
-						<div className="text-text-secondary font-semibold">
-							<div>Lowest</div>
-							<span className="text-sm font-normal">{dateFormatter(sortedLowest?.timestamp || 0)}</span>
-						</div>
-						<div className="text-text-secondary">{formatCurrency((sortedLowest?.value || 0) * 100, 0)}%</div>
-					</div>
-					<div className="flex justify-between">
-						<div className="text-text-secondary font-semibold">
-							<div>Highest</div>
-							<span className="text-sm font-normal">{dateFormatter(sortedHighest?.timestamp || 0)}</span>
-						</div>
-						<div className="text-text-secondary font-normal">{formatCurrency((sortedHighest?.value || 0) * 100, 0)}%</div>
-					</div>
+					)}
 				</div>
 			</div>
 		</AppCard>

--- a/components/PageEcoSystem/HealthRatio.tsx
+++ b/components/PageEcoSystem/HealthRatio.tsx
@@ -50,9 +50,7 @@ export default function HealthRatio() {
 		const d = date.getDate();
 		const m = date.getMonth() + 1;
 		const y = date.getFullYear();
-		const h = String(date.getHours()).padStart(2, "0");
-		const min = String(date.getMinutes()).padStart(2, "0");
-		return `${d}.${m}.${y} ${h}:${min}`;
+		return `${d}.${m}.${y}`;
 	};
 
 	const barPct = Math.min(currentPct / 3, 100);
@@ -107,7 +105,7 @@ export default function HealthRatio() {
 						type="area"
 						height={200}
 						options={{
-							colors: [currentPct >= 150 ? "#22c55e" : currentPct >= 100 ? "#f59e0b" : "#ef4444"],
+							colors: [currentPct >= 150 ? "#0E9F6E" : currentPct >= 100 ? "#f59e0b" : "#ef4444"],
 							stroke: {
 								curve: "smooth",
 								width: 2,

--- a/components/PageEcoSystem/MarketChart.tsx
+++ b/components/PageEcoSystem/MarketChart.tsx
@@ -25,8 +25,6 @@ export default function MarketChart() {
 	return (
 		<div className="grid md:grid-cols-2 gap-4">
 			<AppCard>
-				<div className="mt-4 text-lg font-bold text-center">Exchange Rate</div>
-
 				<div className="-m-4 pr-2">
 					<ApexChart
 						type="line"
@@ -121,8 +119,6 @@ export default function MarketChart() {
 			</AppCard>
 
 			<AppCard>
-				<div className="mt-4 text-lg font-bold text-center">24h Trading Volume</div>
-
 				<div className="-m-4 pr-2">
 					<ApexChart
 						type="bar"

--- a/components/PageEcoSystem/MintOutstanding.tsx
+++ b/components/PageEcoSystem/MintOutstanding.tsx
@@ -4,10 +4,16 @@ import AppCard from "../AppCard";
 import { formatUnits } from "viem";
 import dynamic from "next/dynamic";
 import { formatCurrency, FormatType } from "../../utils/format";
-import AppLink from "@components/AppLink";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import TokenLogo from "@components/TokenLogo";
 const ApexChart = dynamic(() => import("react-apexcharts"), { ssr: false });
 
+const INITIAL_VISIBLE = 6;
+
 export default function MintOutstanding() {
+	const [showAll, setShowAll] = useState(false);
+	const router = useRouter();
 	const { openPositions } = useSelector((state: RootState) => state.positions);
 
 	const mint = openPositions
@@ -19,6 +25,7 @@ export default function MintOutstanding() {
 		}))
 		.sort((a, b) => a.exp - b.exp);
 
+	const mintFiltered = mint.filter((i) => i.mint > 0);
 	const totalMint = mint.reduce((a, b) => a + b.mint, 0n);
 
 	const historyBegin = {
@@ -39,50 +46,50 @@ export default function MintOutstanding() {
 
 	const dateFormatter = (value: number) => {
 		const date = new Date(value);
-		const d = date.getDate();
-		const m = date.getMonth() + 1;
-		const y = date.getFullYear();
-		return `${d}.${m}.${y}`;
+		const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+		return `${date.getDate()} ${months[date.getMonth()]} ${date.getFullYear()}`;
 	};
+
+	const visibleMints = showAll ? mintFiltered : mintFiltered.slice(0, INITIAL_VISIBLE);
 
 	return (
 		<AppCard>
-			<div className="mt-4 text-lg font-bold text-center">Frankencoin Supply Expiration</div>
-
-			<div className="grid md:grid-cols-2 gap-4">
-				<div className="pr-2">
+			<div className="flex flex-col gap-6">
+				{/* Chart */}
+				<div className="-mx-4">
 					<ApexChart
-						type="line"
+						type="area"
+						height={220}
 						options={{
-							theme: {
-								monochrome: {
-									enabled: false,
-								},
-							},
-							colors: ["#092f62", "#0F80F0"],
+							colors: ["#092f62"],
 							stroke: {
-								curve: "linestep",
-								width: 3,
+								curve: "stepline",
+								width: 2,
+							},
+							fill: {
+								type: "gradient",
+								gradient: {
+									shadeIntensity: 1,
+									opacityFrom: 0.15,
+									opacityTo: 0.02,
+									stops: [0, 100],
+								},
 							},
 							chart: {
-								type: "line",
-								height: 100,
-								dropShadow: {
-									enabled: false,
-								},
-								toolbar: {
-									show: false,
-								},
-								zoom: {
-									enabled: false,
-								},
+								type: "area",
+								height: 220,
+								sparkline: { enabled: false },
+								dropShadow: { enabled: false },
+								toolbar: { show: false },
+								zoom: { enabled: false },
 								background: "0",
 							},
-							dataLabels: {
-								enabled: false,
-							},
+							dataLabels: { enabled: false },
 							grid: {
-								show: false,
+								show: true,
+								borderColor: "rgba(128,128,128,0.1)",
+								strokeDashArray: 4,
+								xaxis: { lines: { show: false } },
 							},
 							xaxis: {
 								type: "datetime",
@@ -90,71 +97,62 @@ export default function MintOutstanding() {
 									show: true,
 									formatter: (value) => {
 										const date = new Date(value);
-										const d = date.getDate();
-										const m = date.getMonth() + 1;
-										const y = date.getFullYear();
-										return `${d}.${m}.${y}`;
+										return `${date.getDate()}.${date.getMonth() + 1}.${date.getFullYear()}`;
 									},
 								},
-								axisBorder: {
-									show: false,
-								},
-								axisTicks: {
-									show: false,
-								},
+								axisBorder: { show: false },
+								axisTicks: { show: false },
 							},
 							yaxis: {
 								labels: {
 									show: true,
-									formatter: (value) => {
-										return `${Math.round(value / 100000) / 10} Mio.`;
-									},
+									formatter: (value) => `${Math.round(value / 100000) / 10} Mio.`,
 								},
-								axisBorder: {
-									show: true,
-								},
-								axisTicks: {
-									show: true,
-								},
+								axisBorder: { show: false },
+								axisTicks: { show: false },
 								min: 0,
-								max: (max) => {
-									return max + max * 0.1;
-								},
+								max: (max) => max + max * 0.1,
 							},
 						}}
 						series={[
 							{
-								name: "Mint",
-								data: history.map((entry) => {
-									return [entry.t * 1000, Math.round(parseFloat(formatUnits(entry.m, 16))) / 100];
-								}),
+								name: "Outstanding Supply",
+								data: history.map((entry) => [entry.t * 1000, Math.round(parseFloat(formatUnits(entry.m, 16))) / 100]),
 							},
 						]}
 					/>
 
-					{history.length == 0 ? (
+					{history.length === 0 && (
 						<div className="flex justify-center text-text-warning">No data available for selected timeframe.</div>
-					) : null}
+					)}
 				</div>
 
-				<div className="mt-8 space-y-1 gap-2">
-					{mint
-						.filter((i) => i.mint > 0)
-						.slice(0, 10)
-						.map((d, idx) => (
-							<div key={`${d}_${idx}`} className="flex justify-between">
-								<AppLink
-									className=""
-									href={`/monitoring/${d.pos}`}
-									label={`${dateFormatter(d.exp * 1000)} - ${Math.round(
-										(d.exp * 1000 - Date.now()) / (24 * 3600 * 1000)
-									)}d - ${d.coll}`}
-								/>
-								<div className="text-text-secondary font-semibold">
-									{formatCurrency(formatUnits(d.mint, 18), 2, 2, FormatType.symbol)} ZCHF
-								</div>
+				{/* Maturity list */}
+				<div>
+					{visibleMints.map((d, idx) => (
+						<div
+							key={`${d.pos}_${idx}`}
+							className="grid grid-cols-[1fr_auto_1fr] items-center py-3 border-b border-table-header-secondary last:border-0 cursor-pointer hover:bg-table-row-hover duration-200 px-2 -mx-2 rounded"
+							onClick={() => router.push(`/monitoring/${d.pos}`)}
+						>
+							<div className="text-text-secondary text-sm">{dateFormatter(d.exp * 1000)}</div>
+							<div className="flex items-center gap-2">
+								<TokenLogo currency={d.coll.toLowerCase()} size={5} />
+								<span className="font-semibold text-sm">{d.coll}</span>
 							</div>
-						))}
+							<div className="text-right font-semibold text-sm">
+								{formatCurrency(formatUnits(d.mint, 18), 2, 2, FormatType.symbol)} ZCHF
+							</div>
+						</div>
+					))}
+
+					{mintFiltered.length > INITIAL_VISIBLE && (
+						<div className="text-center mt-4">
+							<button className="text-sm text-blue-500 hover:text-blue-400 duration-200" onClick={() => setShowAll(!showAll)}>
+								{showAll ? "Show less" : `Show all ${mintFiltered.length} maturities`}
+							</button>
+						</div>
+					)}
 				</div>
 			</div>
 		</AppCard>

--- a/components/PageEcoSystem/MintOutstanding.tsx
+++ b/components/PageEcoSystem/MintOutstanding.tsx
@@ -3,7 +3,7 @@ import { RootState } from "../../redux/redux.store";
 import AppCard from "../AppCard";
 import { formatUnits } from "viem";
 import dynamic from "next/dynamic";
-import { formatCurrency } from "../../utils/format";
+import { formatCurrency, FormatType } from "../../utils/format";
 import AppLink from "@components/AppLink";
 const ApexChart = dynamic(() => import("react-apexcharts"), { ssr: false });
 
@@ -150,7 +150,9 @@ export default function MintOutstanding() {
 										(d.exp * 1000 - Date.now()) / (24 * 3600 * 1000)
 									)}d - ${d.coll}`}
 								/>
-								<div className="text-text-secondary font-semibold">{formatCurrency(formatUnits(d.mint, 18), 2)} ZCHF</div>
+								<div className="text-text-secondary font-semibold">
+									{formatCurrency(formatUnits(d.mint, 18), 2, 2, FormatType.symbol)} ZCHF
+								</div>
 							</div>
 						))}
 				</div>

--- a/components/PageEcoSystem/ReserveAllocation.tsx
+++ b/components/PageEcoSystem/ReserveAllocation.tsx
@@ -3,7 +3,7 @@ import { RootState } from "../../redux/redux.store";
 import AppCard from "../AppCard";
 import { formatUnits, parseEther } from "viem";
 import dynamic from "next/dynamic";
-import { formatCurrency } from "../../utils/format";
+import { formatCurrency, FormatType } from "../../utils/format";
 import { colors } from "../../utils/constant";
 const ApexChart = dynamic(() => import("react-apexcharts"), { ssr: false });
 
@@ -100,14 +100,18 @@ export default function ReserveAllocation() {
 							<div className="text-text-secondary font-semibold" style={{ color: colors[idx % colors.length] }}>
 								{label} <span className="text-sm">({percentByLabel.get(label)}%)</span>
 							</div>
-							<div className="text-text-secondary font-semibold">{formatCurrency(series[idx].toString(), 2)} ZCHF</div>
+							<div className="text-text-secondary font-semibold">
+								{formatCurrency(series[idx], 2, 2, FormatType.symbol)} ZCHF
+							</div>
 						</div>
 					))}
 					<div className="flex justify-between">
 						<div className="text-text-primary font-semibold mt-2">
 							Total <span className="text-sm">(100%)</span>
 						</div>
-						<div className="text-text-primary font-semibold mt-2">{formatCurrency(formatUnits(total, 18), 2)} ZCHF</div>
+						<div className="text-text-primary font-semibold mt-2">
+							{formatCurrency(formatUnits(total, 18), 2, 2, FormatType.symbol)} ZCHF
+						</div>
 					</div>
 				</div>
 			</div>

--- a/components/PageEcoSystem/ReserveAllocation.tsx
+++ b/components/PageEcoSystem/ReserveAllocation.tsx
@@ -46,8 +46,6 @@ export default function ReserveAllocation() {
 
 	return (
 		<AppCard>
-			<div className="mt-4 text-lg font-bold text-center">Reserve Attribution</div>
-
 			<div className="grid md:grid-cols-2 gap-4">
 				<div className="pr-2 my-auto">
 					<ApexChart
@@ -94,7 +92,7 @@ export default function ReserveAllocation() {
 					{labels.length == 0 ? <div className="flex justify-center text-text-warning">No data available.</div> : null}
 				</div>
 
-				<div className="mt-8 space-y-1">
+				<div className="my-auto space-y-1">
 					{labels.map((label, idx) => (
 						<div key={`${label}_${idx}`} className="flex justify-between">
 							<div className="text-text-secondary font-semibold" style={{ color: colors[idx % colors.length] }}>

--- a/components/PageEcoSystem/ReserveAllocation.tsx
+++ b/components/PageEcoSystem/ReserveAllocation.tsx
@@ -21,14 +21,22 @@ export default function ReserveAllocation() {
 	// Aggregate swap bridges
 	byCollateral.set("Equity", parseEther(fpsInfo.reserve.equity.toString()));
 
-	const mapping = [...byCollateral.keys()]
-		.map((label, idx) => {
-			return {
-				label,
-				value: byCollateral.get(label) ?? 0n,
-			};
-		})
+	const MAX_ITEMS = 10;
+
+	const sorted = [...byCollateral.keys()]
+		.map((label) => ({ label, value: byCollateral.get(label) ?? 0n }))
 		.sort((a, b) => (b.value > a.value ? 1 : -1));
+
+	const mapping =
+		sorted.length > MAX_ITEMS
+			? [
+					...sorted.slice(0, MAX_ITEMS - 1),
+					{
+						label: "Others",
+						value: sorted.slice(MAX_ITEMS - 1).reduce((a, b) => a + b.value, 0n),
+					},
+				]
+			: sorted;
 
 	const labels = mapping.map((m) => m.label);
 	const rawValues = mapping.map((m) => m.value);

--- a/components/PageGovernance/GovernanceLeadrateCurrent.tsx
+++ b/components/PageGovernance/GovernanceLeadrateCurrent.tsx
@@ -75,6 +75,31 @@ export default function GovernanceLeadrateCurrent({}: Props) {
 	const matchingRatesMint = [latestDefaultEntryMint, ...rates[MintModule]];
 	const matchingRatesSave = [latestDefaultEntrySave, ...rates[SaveModule]];
 
+	// Bug in AbstractLeadrate.sol line 40: uint40 overflow in updateRate().
+	// ticksAnchor += (timeNow - anchorTime) * currentRatePPM overflows uint40
+	// when (elapsed seconds) * ratePPM > 2^40 - 1.
+	// Each rate change resets the countdown. After the deadline, any updateRate() call will revert.
+	const UINT40_MAX = 2n ** 40n - 1n;
+	const calcOverflowTimestamp = (module: Address) => {
+		const ratePPM = rate[module].approvedRate;
+		if (ratePPM <= 0) return null;
+		const anchor = rate[module].created;
+		const maxElapsed = Number(UINT40_MAX / BigInt(ratePPM));
+		return anchor + maxElapsed;
+	};
+	const formatOverflowWarning = (overflowTs: number | null) => {
+		if (!overflowTs) return null;
+		const now = Math.floor(Date.now() / 1000);
+		if (overflowTs <= now) return "Contract is bricked: uint40 overflow reached, rate changes will permanently revert.";
+		const daysLeft = Math.floor((overflowTs - now) / 86400);
+		const date = new Date(overflowTs * 1000);
+		const dateStr = `${date.getDate()}.${date.getMonth() + 1}.${date.getFullYear()}`;
+		if (daysLeft < 90) return `Apply new rate before ${dateStr} (~${daysLeft}d) due to uint40 overflow in contract.`;
+		return null;
+	};
+	const overflowWarningMint = formatOverflowWarning(calcOverflowTimestamp(MintModule));
+	const overflowWarningSave = formatOverflowWarning(calcOverflowTimestamp(SaveModule));
+
 	const handleOnClickMint = async function (e: any) {
 		e.preventDefault();
 		if (!account.address) return;
@@ -279,6 +304,7 @@ export default function GovernanceLeadrateCurrent({}: Props) {
 						value={newRateMint.toString()}
 						digit={4}
 						onChange={(e) => setNewRateMint(BigInt(e))}
+						warning={overflowWarningMint ?? undefined}
 					/>
 
 					<div className="h-10 mb-4">
@@ -300,6 +326,7 @@ export default function GovernanceLeadrateCurrent({}: Props) {
 						value={newRateSave.toString()}
 						digit={4}
 						onChange={(e) => setNewRateSave(BigInt(e))}
+						warning={overflowWarningSave ?? undefined}
 					/>
 
 					<div className="h-10 mb-4">

--- a/components/PageGovernance/GovernanceVotersRow.tsx
+++ b/components/PageGovernance/GovernanceVotersRow.tsx
@@ -36,7 +36,7 @@ export default function GovernanceVotersRow({ headers, tab, voter, votesTotal, c
 				{/* Voting power + supported VP ratio as sub-text */}
 				<div className={`flex flex-col ${connectedWallet ? "font-semibold" : ""}`}>
 					<span>{formatCurrency(votingPower * 100)}%</span>
-					{voter.supportedVotingPowerRatio > 0 && (
+					{supporterCount > 0 && (
 						<span className="text-sm text-text-subheader font-normal">
 							{formatCurrency(voter.supportedVotingPowerRatio * 100)}%
 						</span>

--- a/components/PageMonitoring/AuctionCard.tsx
+++ b/components/PageMonitoring/AuctionCard.tsx
@@ -1,0 +1,45 @@
+import { ChallengesQueryItem, PositionQuery } from "@frankencoin/api";
+import { formatUnits } from "viem";
+import { formatCurrency, formatDate, normalizeAddress } from "@utils";
+import { useRouter as useNavigation } from "next/navigation";
+import Button from "@components/Button";
+import StatRow from "./StatRow";
+
+interface Props {
+	position: PositionQuery;
+	challenge: ChallengesQueryItem;
+}
+
+export default function AuctionCard({ position, challenge }: Props) {
+	const navigate = useNavigation();
+
+	const priceDigit = 36 - position.collateralDecimals;
+	const total = Number(formatUnits(challenge.size, position.collateralDecimals));
+	const remaining = Number(formatUnits(challenge.size - challenge.filledSize, position.collateralDecimals));
+	const fillPct = total > 0 ? ((total - remaining) / total) * 100 : 0;
+	const liqPrice = formatCurrency(formatUnits(challenge.liqPrice, priceDigit), 2, 2);
+
+	return (
+		<div className="rounded-lg bg-card-content-primary p-3 flex flex-col gap-2">
+			<div className="text-sm font-semibold text-text-primary">Auction #{String(challenge.number)}</div>
+
+			<StatRow label="Remaining">
+				{formatCurrency(remaining, 2, 2)} / {formatCurrency(total, 2, 2)} {position.collateralSymbol}
+			</StatRow>
+			<StatRow label="Liq. Price">{liqPrice} ZCHF</StatRow>
+			<StatRow label="Started">{formatDate(Number(challenge.start))}</StatRow>
+
+			<div className="h-1.5 rounded-full bg-table-header-secondary overflow-hidden">
+				<div className="h-full rounded-full bg-red-400 transition-all" style={{ width: `${fillPct}%` }} />
+			</div>
+			<div className="text-xs text-text-secondary">{formatCurrency(fillPct, 1, 1)}% filled</div>
+
+			<Button
+				className="h-9 mt-1"
+				onClick={() => navigate.push(`/monitoring/${normalizeAddress(challenge.position)}/auction/${challenge.number}`)}
+			>
+				Place Bid
+			</Button>
+		</div>
+	);
+}

--- a/components/PageMonitoring/CollateralOverviewTable.tsx
+++ b/components/PageMonitoring/CollateralOverviewTable.tsx
@@ -223,8 +223,8 @@ export default function CollateralOverviewTable() {
 								</div>
 
 								{/* Avg Coll. Ratio */}
-								<div className={`text-md font-bold ${stat.minted > 0n ? collColor : ""}`}>
-									{stat.minted > 0n ? formatCurrency(avgCollPct, 2, 2) : "- "}%
+								<div className={`text-md font-bold ${!isBridge && stat.minted > 0n ? collColor : ""}`}>
+									{isBridge || stat.minted === 0n ? "" : `${formatCurrency(avgCollPct, 2, 2)}%`}
 								</div>
 							</TableRow>
 							</div>

--- a/components/PageMonitoring/CollateralOverviewTable.tsx
+++ b/components/PageMonitoring/CollateralOverviewTable.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { useAccount, useReadContracts } from "wagmi";
-import { erc20Abi, formatUnits, zeroAddress } from "viem";
+import { Address, erc20Abi, formatUnits, zeroAddress } from "viem";
 import { RootState } from "../../redux/redux.store";
 import { calcOverviewStats } from "@components/PageEcoSystem/CollateralAndPositionsOverview";
 import Table from "../Table";
@@ -13,6 +13,11 @@ import TokenLogo from "@components/TokenLogo";
 import { formatCurrency, normalizeAddress, ALL_CATEGORIES, CollateralCategory, collateralMatchesCategories, FormatType } from "@utils";
 import AppBox from "@components/AppBox";
 import { FilterOption } from "@components/Table/TableHeadSearchable";
+import { useSwapVCHFStats } from "@hooks";
+import { ADDRESS } from "@frankencoin/zchf";
+import { mainnet } from "viem/chains";
+import { PositionQuery } from "@frankencoin/api";
+import { useRouter } from "next/navigation";
 
 const headers = ["Collateral", "Total Value", "Total Minted", "Available", "Avg Coll. Ratio"];
 const FILTER_OPTIONS: FilterOption[] = ALL_CATEGORIES.map((c) => ({ label: c, value: c }));
@@ -24,15 +29,71 @@ export default function CollateralOverviewTable() {
 	const [tab, setTab] = useState(headers[2]);
 	const [reverse, setReverse] = useState(false);
 
+	const router = useRouter();
 	const { address: walletAddress } = useAccount();
 	const { list, openPositionsByCollateral } = useSelector((state: RootState) => state.positions);
 	const { coingecko } = useSelector((state: RootState) => state.prices);
+	const vchfBridge = useSwapVCHFStats();
+	const bridgePosition = normalizeAddress(ADDRESS[mainnet.id].stablecoinBridgeVCHF);
 
-	const stats = useMemo(
+	const positionStats = useMemo(
 		() => calcOverviewStats(openPositionsByCollateral, list.list, coingecko),
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[openPositionsByCollateral, list.list, coingecko]
 	);
+
+	const stats = useMemo(() => {
+		const chainId = mainnet.id;
+		const VCHF_Address: Address = normalizeAddress(ADDRESS[chainId].vchfToken);
+		const vchfPrice = coingecko[VCHF_Address]?.price?.chf || 1;
+		const bridgeLimit = vchfBridge.bridgeLimit;
+		const otherBridgeBal = vchfBridge.otherBridgeBal;
+		const available = bridgeLimit - otherBridgeBal;
+		const totalValue = Math.round(Number(formatUnits(otherBridgeBal, 18)) * vchfPrice);
+
+		const vchfStat = {
+			original: {
+				position: ADDRESS[chainId].stablecoinBridgeVCHF,
+			} as PositionQuery,
+			originals: [],
+			clones: [],
+			balance: otherBridgeBal,
+			collateral: coingecko[VCHF_Address] || {
+				chainId,
+				address: VCHF_Address,
+				name: "VNX Franc",
+				symbol: "VCHF",
+				decimals: 18,
+				price: { chf: vchfPrice },
+				timestamp: 0,
+			},
+			mint: coingecko[normalizeAddress(ADDRESS[chainId].frankencoin)] || {
+				chainId,
+				address: ADDRESS[chainId].frankencoin,
+				name: "Frankencoin",
+				symbol: "ZCHF",
+				decimals: 18,
+				price: { chf: 1 },
+				timestamp: 0,
+			},
+			minted: otherBridgeBal,
+			reserve: 0n,
+			limitForClones: bridgeLimit / 10n ** 18n,
+			availableForClones: available / 10n ** 18n,
+			totalValue,
+			avgCollateral: vchfPrice,
+			highestZCHFPrice: vchfPrice,
+			collateralizedPct: vchfPrice * 100,
+			availableForClonesPct: bridgeLimit > 0n ? Math.round((Number(available) / Number(bridgeLimit)) * 10000) / 100 : 0,
+			collateralPriceInZCHF: vchfPrice,
+			worstStatusColors: "green-300",
+			lowestInterestRate: 0,
+			discussionLink: "",
+			lockedValue: Number(formatUnits(otherBridgeBal, 18)) * vchfPrice,
+		};
+
+		return [...positionStats, vchfStat];
+	}, [positionStats, vchfBridge, coingecko]);
 
 	const uniqueCollaterals = useMemo(() => stats.map((s) => normalizeAddress(s.collateral.address)), [stats]);
 
@@ -116,9 +177,11 @@ export default function CollateralOverviewTable() {
 						const balanceFormatted = formatCurrency(Number(formatUnits(stat.balance, stat.collateral.decimals)), 2, 2);
 						const avgCollPct = stat.avgCollateral * 100;
 						const collColor = avgCollPct < 110 ? "text-red-500" : avgCollPct <= 120 ? "text-orange-400" : "text-green-500";
+						const isBridge = normalizeAddress(stat.original.position) === bridgePosition;
 
 						return (
-							<TableRow headers={headers} tab={tab} key={stat.original.position}>
+							<div key={stat.original.position} onClick={isBridge ? () => router.push("/swap") : undefined}>
+							<TableRow headers={headers} tab={tab} className={isBridge ? "cursor-pointer" : ""}>
 								{/* Collateral */}
 								<div className="flex flex-col max-md:mb-5">
 									<div className="max-md:hidden md:-ml-12 flex items-center">
@@ -164,6 +227,7 @@ export default function CollateralOverviewTable() {
 									{stat.minted > 0n ? formatCurrency(avgCollPct, 2, 2) : "- "}%
 								</div>
 							</TableRow>
+							</div>
 						);
 					})
 				)}

--- a/components/PageMonitoring/CollateralOverviewTable.tsx
+++ b/components/PageMonitoring/CollateralOverviewTable.tsx
@@ -14,14 +14,14 @@ import { formatCurrency, normalizeAddress, ALL_CATEGORIES, CollateralCategory, c
 import AppBox from "@components/AppBox";
 import { FilterOption } from "@components/Table/TableHeadSearchable";
 
-const headers = ["Collateral", "Total Value", "Positions", "Total Minted", "Avg Coll. Ratio"];
+const headers = ["Collateral", "Total Value", "Total Minted", "Available", "Avg Coll. Ratio"];
 const FILTER_OPTIONS: FilterOption[] = ALL_CATEGORIES.map((c) => ({ label: c, value: c }));
 
 export default function CollateralOverviewTable() {
 	const [searchQuery, setSearchQuery] = useState("");
 	const [activeCategories, setActiveCategories] = useState<string[]>([]);
 	const [inMyWallet, setInMyWallet] = useState(false);
-	const [tab, setTab] = useState(headers[3]);
+	const [tab, setTab] = useState(headers[2]);
 	const [reverse, setReverse] = useState(false);
 
 	const { address: walletAddress } = useAccount();
@@ -58,8 +58,8 @@ export default function CollateralOverviewTable() {
 		const s = [...stats].sort((a, b) => {
 			if (tab === headers[0]) return a.collateral.name.localeCompare(b.collateral.name);
 			if (tab === headers[1]) return b.totalValue - a.totalValue;
-			if (tab === headers[2]) return b.originals.length + b.clones.length - (a.originals.length + a.clones.length);
-			if (tab === headers[3]) return Number(b.minted) - Number(a.minted);
+			if (tab === headers[2]) return Number(b.minted) - Number(a.minted);
+			if (tab === headers[3]) return Number(b.availableForClones) - Number(a.availableForClones);
 			if (tab === headers[4]) return b.avgCollateral - a.avgCollateral;
 			return 0;
 		});
@@ -113,7 +113,6 @@ export default function CollateralOverviewTable() {
 					<TableRowEmpty>No collateral found.</TableRowEmpty>
 				) : (
 					filtered.map((stat) => {
-						const posCount = stat.originals.length + stat.clones.length;
 						const balanceFormatted = formatCurrency(Number(formatUnits(stat.balance, stat.collateral.decimals)), 2, 2);
 						const avgCollPct = stat.avgCollateral * 100;
 						const collColor = avgCollPct < 110 ? "text-red-500" : avgCollPct <= 120 ? "text-orange-400" : "text-green-500";
@@ -152,11 +151,13 @@ export default function CollateralOverviewTable() {
 								{/* Total Value */}
 								<div className="text-md">{formatCurrency(stat.totalValue, 2, 2, FormatType.symbol)} ZCHF</div>
 
-								{/* Positions */}
-								<div className="text-md">{posCount}</div>
-
 								{/* Total Minted */}
 								<div className="text-md">{formatCurrency(formatUnits(stat.minted, 18), 2, 2, FormatType.symbol)} ZCHF</div>
+
+								{/* Available */}
+								<div className="text-md">
+									{formatCurrency(Number(stat.availableForClones), 2, 2, FormatType.symbol)} ZCHF
+								</div>
 
 								{/* Avg Coll. Ratio */}
 								<div className={`text-md font-bold ${stat.minted > 0n ? collColor : ""}`}>

--- a/components/PageMonitoring/CollateralOverviewTable.tsx
+++ b/components/PageMonitoring/CollateralOverviewTable.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from "react";
+import { useSelector } from "react-redux";
+import { useAccount, useReadContracts } from "wagmi";
+import { erc20Abi, formatUnits, zeroAddress } from "viem";
+import { RootState } from "../../redux/redux.store";
+import { calcOverviewStats } from "@components/PageEcoSystem/CollateralAndPositionsOverview";
+import Table from "../Table";
+import TableBody from "../Table/TableBody";
+import TableRow from "../Table/TableRow";
+import TableRowEmpty from "../Table/TableRowEmpty";
+import TableHeadSearchable from "../Table/TableHeadSearchable";
+import TokenLogo from "@components/TokenLogo";
+import { formatCurrency, normalizeAddress, ALL_CATEGORIES, CollateralCategory, collateralMatchesCategories, FormatType } from "@utils";
+import AppBox from "@components/AppBox";
+import { FilterOption } from "@components/Table/TableHeadSearchable";
+
+const headers = ["Collateral", "Total Value", "Positions", "Total Minted", "Avg Coll. Ratio"];
+const FILTER_OPTIONS: FilterOption[] = ALL_CATEGORIES.map((c) => ({ label: c, value: c }));
+
+export default function CollateralOverviewTable() {
+	const [searchQuery, setSearchQuery] = useState("");
+	const [activeCategories, setActiveCategories] = useState<string[]>([]);
+	const [inMyWallet, setInMyWallet] = useState(false);
+	const [tab, setTab] = useState(headers[3]);
+	const [reverse, setReverse] = useState(false);
+
+	const { address: walletAddress } = useAccount();
+	const { list, openPositionsByCollateral } = useSelector((state: RootState) => state.positions);
+	const { coingecko } = useSelector((state: RootState) => state.prices);
+
+	const stats = useMemo(
+		() => calcOverviewStats(openPositionsByCollateral, list.list, coingecko),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[openPositionsByCollateral, list.list, coingecko]
+	);
+
+	const uniqueCollaterals = useMemo(() => stats.map((s) => normalizeAddress(s.collateral.address)), [stats]);
+
+	const { data: balanceResults } = useReadContracts({
+		contracts: uniqueCollaterals.map((addr) => ({
+			address: addr,
+			abi: erc20Abi,
+			functionName: "balanceOf" as const,
+			args: [walletAddress ?? zeroAddress],
+		})),
+		query: { enabled: !!walletAddress && inMyWallet },
+	});
+
+	const walletBalanceMap = useMemo(() => {
+		const map: Record<string, bigint> = {};
+		uniqueCollaterals.forEach((addr, i) => {
+			map[addr] = (balanceResults?.[i]?.result as bigint | undefined) ?? 0n;
+		});
+		return map;
+	}, [uniqueCollaterals, balanceResults]);
+
+	const sorted = useMemo(() => {
+		const s = [...stats].sort((a, b) => {
+			if (tab === headers[0]) return a.collateral.name.localeCompare(b.collateral.name);
+			if (tab === headers[1]) return b.totalValue - a.totalValue;
+			if (tab === headers[2]) return b.originals.length + b.clones.length - (a.originals.length + a.clones.length);
+			if (tab === headers[3]) return Number(b.minted) - Number(a.minted);
+			if (tab === headers[4]) return b.avgCollateral - a.avgCollateral;
+			return 0;
+		});
+		return reverse ? s.reverse() : s;
+	}, [stats, tab, reverse]);
+
+	const filtered = useMemo(() => {
+		return sorted.filter((s) => {
+			if (searchQuery) {
+				const q = searchQuery.toLowerCase();
+				if (!s.collateral.name.toLowerCase().includes(q) && !s.collateral.symbol.toLowerCase().includes(q)) return false;
+			}
+			if (
+				activeCategories.length > 0 &&
+				!collateralMatchesCategories(normalizeAddress(s.collateral.address), activeCategories as CollateralCategory[])
+			)
+				return false;
+			if (inMyWallet && walletAddress && (walletBalanceMap[normalizeAddress(s.collateral.address)] ?? 0n) === 0n) return false;
+			return true;
+		});
+	}, [sorted, searchQuery, activeCategories, inMyWallet, walletAddress, walletBalanceMap]);
+
+	const handleTabChange = (header: string) => {
+		if (tab === header) {
+			setReverse((r) => !r);
+		} else {
+			setTab(header);
+			setReverse(false);
+		}
+	};
+
+	return (
+		<Table>
+			<TableHeadSearchable
+				headers={headers}
+				searchPlaceholder="Search collateral"
+				searchValue={searchQuery}
+				onSearchChange={setSearchQuery}
+				hideMyWallet={!walletAddress}
+				inMyWallet={inMyWallet}
+				onInMyWalletChange={setInMyWallet}
+				filterOptions={FILTER_OPTIONS}
+				activeFilters={activeCategories}
+				onFiltersChange={setActiveCategories}
+				tab={tab}
+				reverse={reverse}
+				tabOnChange={handleTabChange}
+			/>
+			<TableBody>
+				{filtered.length === 0 ? (
+					<TableRowEmpty>No collateral found.</TableRowEmpty>
+				) : (
+					filtered.map((stat) => {
+						const posCount = stat.originals.length + stat.clones.length;
+						const balanceFormatted = formatCurrency(Number(formatUnits(stat.balance, stat.collateral.decimals)), 2, 2);
+						const avgCollPct = stat.avgCollateral * 100;
+						const collColor = avgCollPct < 110 ? "text-red-500" : avgCollPct <= 120 ? "text-orange-400" : "text-green-500";
+
+						return (
+							<TableRow headers={headers} tab={tab} key={stat.original.position}>
+								{/* Collateral */}
+								<div className="flex flex-col max-md:mb-5">
+									<div className="max-md:hidden md:-ml-12 flex items-center">
+										<span className="mr-4">
+											<TokenLogo currency={stat.collateral.symbol.toLowerCase()} />
+										</span>
+										<div className="flex flex-col text-left">
+											<span className="font-bold text-md max-lg:w-[8rem] lg:w-[10rem] max-sm:w-[12rem] md:text-nowrap truncate">
+												{stat.collateral.name}
+											</span>
+											<span className="text-text-subheader text-sm">
+												{balanceFormatted} {stat.collateral.symbol}
+											</span>
+										</div>
+									</div>
+
+									<AppBox className="md:hidden flex flex-row items-center">
+										<span className="mr-4">
+											<TokenLogo currency={stat.collateral.symbol.toLowerCase()} />
+										</span>
+										<div className="flex flex-col text-left">
+											<span className="font-bold text-md">{stat.collateral.name}</span>
+											<span className="text-text-subheader text-sm">
+												{balanceFormatted} {stat.collateral.symbol}
+											</span>
+										</div>
+									</AppBox>
+								</div>
+
+								{/* Total Value */}
+								<div className="text-md">{formatCurrency(stat.totalValue, 2, 2, FormatType.symbol)} ZCHF</div>
+
+								{/* Positions */}
+								<div className="text-md">{posCount}</div>
+
+								{/* Total Minted */}
+								<div className="text-md">{formatCurrency(formatUnits(stat.minted, 18), 2, 2, FormatType.symbol)} ZCHF</div>
+
+								{/* Avg Coll. Ratio */}
+								<div className={`text-md font-bold ${stat.minted > 0n ? collColor : ""}`}>
+									{stat.minted > 0n ? formatCurrency(avgCollPct, 2, 2) : "- "}%
+								</div>
+							</TableRow>
+						);
+					})
+				)}
+			</TableBody>
+		</Table>
+	);
+}

--- a/components/PageMonitoring/MintingUpdatesTable.tsx
+++ b/components/PageMonitoring/MintingUpdatesTable.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import { MintingUpdateQuery, PositionQuery } from "@frankencoin/api";
+import Table from "@components/Table";
+import TableHead from "@components/Table/TableHead";
+import TableBody from "@components/Table/TableBody";
+import TableRow from "@components/Table/TableRow";
+import TableRowEmpty from "@components/Table/TableRowEmpty";
+import AppLink from "@components/AppLink";
+import { formatCurrency, formatDate, TxUrl } from "@utils";
+import { formatUnits, Hash } from "viem";
+
+const HEADERS = ["Date", "Price", "Δ Minted", "Δ Collateral", "Fee Paid"];
+
+type EnrichedUpdate = {
+	update: MintingUpdateQuery;
+	mintDelta: bigint;
+	collDelta: bigint;
+	isFirst: boolean;
+};
+
+interface Props {
+	updates: MintingUpdateQuery[];
+	position: PositionQuery;
+}
+
+export default function MintingUpdatesTable({ updates, position }: Props) {
+	const [tab, setTab] = useState(HEADERS[0]);
+	const [reverse, setReverse] = useState(false);
+
+	const priceDigit = 36 - position.collateralDecimals;
+
+	// Always compute deltas in chronological order (ascending count)
+	const chronological = [...updates].sort((a, b) => a.count - b.count);
+	const enriched: EnrichedUpdate[] = chronological.map((u, i) => ({
+		update: u,
+		mintDelta: BigInt(u.minted) - BigInt(chronological[i - 1]?.minted ?? "0"),
+		collDelta: BigInt(u.size) - BigInt(chronological[i - 1]?.size ?? "0"),
+		isFirst: i === 0,
+	}));
+
+	const sorted = [...enriched].sort((a, b) => {
+		switch (tab) {
+			case "Date":
+				return b.update.count - a.update.count;
+			case "Price":
+				return Number(BigInt(b.update.price) - BigInt(a.update.price));
+			case "Δ Minted":
+				return Number(b.mintDelta - a.mintDelta);
+			case "Δ Collateral":
+				return Number(b.collDelta - a.collDelta);
+			case "Fee Paid":
+				return Number(BigInt(b.update.feePaid) - BigInt(a.update.feePaid));
+			default:
+				return 0;
+		}
+	});
+
+	const displayed = reverse ? [...sorted].reverse() : sorted;
+
+	const handleTabChange = (header: string) => {
+		if (tab === header) setReverse((r) => !r);
+		else {
+			setTab(header);
+			setReverse(false);
+		}
+	};
+
+	return (
+		<Table>
+			<TableHead headers={HEADERS} tab={tab} reverse={reverse} tabOnChange={handleTabChange} />
+			<TableBody>
+				{displayed.length === 0 ? (
+					<TableRowEmpty>No minting updates found.</TableRowEmpty>
+				) : (
+					displayed.map(({ update, mintDelta, collDelta, isFirst }, idx) => (
+						<MintingUpdateRow
+							key={update.txHash || idx}
+							update={update}
+							position={position}
+							priceDigit={priceDigit}
+							mintDelta={mintDelta}
+							collDelta={collDelta}
+							isFirst={isFirst}
+							tab={tab}
+						/>
+					))
+				)}
+			</TableBody>
+		</Table>
+	);
+}
+
+interface RowProps {
+	update: MintingUpdateQuery;
+	position: PositionQuery;
+	priceDigit: number;
+	mintDelta: bigint;
+	collDelta: bigint;
+	isFirst: boolean;
+	tab: string;
+}
+
+function MintingUpdateRow({ update, position, priceDigit, mintDelta, collDelta, isFirst, tab }: RowProps) {
+	const feePaid = BigInt(update.feePaid);
+	const priceProposed = !isFirst && BigInt(update.priceAdjusted) > 0n;
+
+	return (
+		<TableRow headers={HEADERS} tab={tab} rawHeader={true}>
+			{/* Date → tx link */}
+			<div className="text-left">
+				<AppLink className="" label={formatDate(update.created)} href={TxUrl(update.txHash as Hash)} external={true} />
+			</div>
+
+			{/* Liq price — highlighted if changed this tx */}
+			<div className={`text-right ${priceProposed ? "text-amber-400 font-medium" : ""}`}>
+				{formatCurrency(formatUnits(BigInt(update.price), priceDigit))} ZCHF
+			</div>
+
+			{/* Δ Minted */}
+			<div className="text-right">
+				{mintDelta > 0n ? (
+					<span className="text-green-500">+{formatCurrency(formatUnits(mintDelta, 18))} ZCHF</span>
+				) : mintDelta < 0n ? (
+					<span className="text-red-400">{formatCurrency(formatUnits(mintDelta, 18))} ZCHF</span>
+				) : (
+					<span className="text-text-secondary">—</span>
+				)}
+			</div>
+
+			{/* Δ Collateral */}
+			<div className="text-right">
+				{collDelta > 0n ? (
+					<span className="text-green-500">
+						+{formatCurrency(formatUnits(collDelta, position.collateralDecimals))} {position.collateralSymbol}
+					</span>
+				) : collDelta < 0n ? (
+					<span className="text-red-400">
+						{formatCurrency(formatUnits(collDelta, position.collateralDecimals))} {position.collateralSymbol}
+					</span>
+				) : (
+					<span className="text-text-secondary">—</span>
+				)}
+			</div>
+
+			{/* Fee Paid */}
+			<div className="text-right">
+				{feePaid > 0n ? <>{formatCurrency(formatUnits(feePaid, 18))} ZCHF</> : <span className="text-text-secondary">—</span>}
+			</div>
+		</TableRow>
+	);
+}

--- a/components/PageMonitoring/MonitoringRow.tsx
+++ b/components/PageMonitoring/MonitoringRow.tsx
@@ -1,13 +1,12 @@
-import { Address, formatUnits, zeroAddress } from "viem";
+import { formatUnits, zeroAddress } from "viem";
 import TableRow from "../Table/TableRow";
-import { PositionQuery, ChallengesQueryStatus, BidsQueryItem, BidsQueryType, ChallengesQueryItem } from "@frankencoin/api";
+import { PositionQuery, ChallengesQueryItem } from "@frankencoin/api";
 import { RootState } from "../../redux/redux.store";
 import { useSelector } from "react-redux";
 import TokenLogo from "@components/TokenLogo";
 import { formatCurrency, normalizeAddress } from "../../utils/format";
-import { useRouter as useNavigation } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useContractUrl } from "@hooks";
-import AppBox from "@components/AppBox";
 import ButtonSecondary from "@components/ButtonSecondary";
 
 interface Props {
@@ -17,7 +16,7 @@ interface Props {
 }
 
 export default function MonitoringRow({ headers, tab, position }: Props) {
-	const navigate = useNavigation();
+	const router = useRouter();
 	const isFirstTabActive = headers[0] === tab;
 
 	const prices = useSelector((state: RootState) => state.prices.coingecko);
@@ -30,13 +29,12 @@ export default function MonitoringRow({ headers, tab, position }: Props) {
 
 	const balance: number = Math.round((parseInt(position.collateralBalance) / 10 ** position.collateralDecimals) * 100) / 100;
 	const balanceZCHF: number = Math.round(((balance * collTokenPrice) / zchfPrice) * 100) / 100;
-
 	const liquidationZCHF: number = Math.round((parseInt(position.price) / 10 ** (36 - position.collateralDecimals)) * 100) / 100;
 	const liquidationPct: number = Math.round((balanceZCHF / (liquidationZCHF * balance)) * 10000) / 100;
 
 	const digits: number = position.collateralDecimals;
 	const positionChallenges = challenges.map[normalizeAddress(position.position)] ?? [];
-	const positionChallengesActive = positionChallenges.filter((ch: ChallengesQueryItem) => ch.status == "Active") ?? [];
+	const positionChallengesActive = positionChallenges.filter((ch: ChallengesQueryItem) => ch.status === "Active");
 	const positionChallengesActiveCollateral =
 		positionChallengesActive.reduce<number>((acc, c) => {
 			return acc + parseInt(formatUnits(c.size, digits - 2)) - parseInt(formatUnits(c.filledSize, digits - 2));
@@ -44,19 +42,23 @@ export default function MonitoringRow({ headers, tab, position }: Props) {
 	const collateralBalanceNumber: number = parseInt(formatUnits(BigInt(position.collateralBalance), digits - 2)) / 100;
 	const challengesRatioPct: number = Math.round((positionChallengesActiveCollateral / collateralBalanceNumber) * 100);
 
-	const openExplorer = (e: any) => {
-		e.preventDefault();
-		window.open(url, "_blank");
-	};
+	const collColor = liquidationPct < 110 ? "text-red-500" : liquidationPct <= 120 ? "text-orange-400" : "text-green-500";
+	const rowBg =
+		liquidationPct < 110
+			? "bg-[#FEF2F2] border-l-[3px] border-l-[#E5484D]"
+			: liquidationPct <= 120
+			? "bg-[#FFFBEB] border-l-[3px] border-l-[#F59E0B]"
+			: "";
 
 	return (
 		<TableRow
 			headers={headers}
 			tab={tab}
+			className={rowBg}
 			actionCol={
 				<ButtonSecondary
 					className="h-10"
-					onClick={() => navigate.push(`/monitoring/${position.position}/${maturity <= 0 ? "forceSell" : "challenge"}`)}
+					onClick={() => router.push(`/monitoring/${position.position}/${maturity <= 0 ? "forceSell" : "challenge"}`)}
 				>
 					{maturity <= 0 ? "Force Sell" : "Challenge"}
 				</ButtonSecondary>
@@ -64,46 +66,62 @@ export default function MonitoringRow({ headers, tab, position }: Props) {
 		>
 			{/* Collateral */}
 			<div className="flex flex-col max-md:mb-5">
-				{/* desktop view */}
-				<div className="max-md:hidden flex flex-row items-center -ml-12">
-					<span className="mr-4 cursor-pointer" onClick={openExplorer}>
+				<div className="max-md:hidden md:-ml-12 flex items-center">
+					<span className="mr-4 cursor-pointer" onClick={() => window.open(url, "_blank")}>
 						<TokenLogo currency={position.collateralSymbol} />
 					</span>
-					<span className={`col-span-2 text-md text-text-primary`}>
-						{`${formatCurrency(balance)} ${position.collateralSymbol}`}
-						<span className="text-sm">{position.version == 2 ? " v2" : " v1"}</span>
-					</span>
+					<div className="flex flex-col text-left">
+						<span className="text-md font-bold">{`${formatCurrency(balance)} ${position.collateralSymbol}`}</span>
+						<span className="text-text-subheader font-normal text-sm max-lg:w-[8rem] lg:w-[10rem] max-sm:w-[12rem] md:text-nowrap truncate">
+							{position.collateralName}
+						</span>
+					</div>
 				</div>
 
-				{/* mobile view */}
-				<AppBox className="md:hidden flex flex-row items-center">
-					<div className="mr-4 cursor-pointer" onClick={openExplorer}>
+				<div className="md:hidden flex flex-row items-center">
+					<div className="mr-4 cursor-pointer" onClick={() => window.open(url, "_blank")}>
 						<TokenLogo currency={position.collateralSymbol} />
 					</div>
-					<div className={`col-span-2 text-md ${isFirstTabActive ? "text-text-primary" : ""} font-semibold`}>
-						{`${formatCurrency(balance)} ${position.collateralSymbol}`}
-						<span className="text-sm font-normal">{position.version == 2 ? " v2" : " v1"}</span>
+					<div className="flex flex-col text-left">
+						<span className="text-md font-bold">{`${formatCurrency(balance)} ${position.collateralSymbol}`}</span>
+						<span className="text-text-subheader font-normal text-sm">{position.collateralName}</span>
 					</div>
-				</AppBox>
+				</div>
+			</div>
+
+			{/* Price */}
+			<div className="flex flex-col">
+				<div className={`text-md font-bold`}>{formatCurrency(liquidationZCHF)} ZCHF</div>
+				<div className={`text-sm font-normal text-text-subheader`}>per {position.collateralSymbol}</div>
 			</div>
 
 			{/* Coll. */}
 			<div className="flex flex-col gap-2">
-				<div className={`col-span-2 text-md ${liquidationPct < 110 ? "text-text-warning font-bold" : ""}`}>
-					{!isNaN(liquidationPct) ? formatCurrency(liquidationPct) : "-.--"}%
-				</div>
-			</div>
-
-			{/* Expiration */}
-			<div className="flex flex-col gap-2">
-				<div className={`col-span-2 text-md ${maturity < 7 ? "text-text-warning font-bold" : ""}`}>
-					{maturity < 3 ? (maturity > 0 ? `${formatCurrency(maturity * 24)} hours` : "Expired") : `${Math.round(maturity)} days`}
-				</div>
+				<div className={`text-md font-bold ${collColor}`}>{!isNaN(liquidationPct) ? formatCurrency(liquidationPct) : "-.--"}%</div>
 			</div>
 
 			{/* Challenges */}
-			<div className="flex flex-col gap-2">
-				<div className={`col-span-2 text-md`}>{challengesRatioPct == 0 ? "-" : `${challengesRatioPct}%`}</div>
+			<div className="flex flex-col">
+				{challengesRatioPct === 0 ? (
+					<span className="text-md">-</span>
+				) : (
+					<>
+						<span className="text-md font-bold">{challengesRatioPct}%</span>
+						<span className="text-text-subheader text-sm">
+							{formatCurrency(positionChallengesActiveCollateral, 2, 2)} {position.collateralSymbol}
+						</span>
+					</>
+				)}
+			</div>
+
+			{/* Expiration */}
+			<div className="flex flex-col">
+				<span className="text-md">
+					{new Date(position.expiration * 1000).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })}
+				</span>
+				<span className={`text-sm ${maturity < 7 ? "text-text-warning font-bold" : "text-text-subheader"}`}>
+					{maturity <= 0 ? "Expired" : maturity < 3 ? `${Math.round(maturity * 24)}h` : `${Math.round(maturity)}d`}
+				</span>
 			</div>
 		</TableRow>
 	);

--- a/components/PageMonitoring/MonitoringTable.tsx
+++ b/components/PageMonitoring/MonitoringTable.tsx
@@ -12,14 +12,16 @@ import { useAccount, useReadContracts } from "wagmi";
 import { ALL_CATEGORIES, CollateralCategory, collateralMatchesCategories, normalizeAddress } from "@utils";
 
 const FILTER_OPTIONS: FilterOption[] = ALL_CATEGORIES.map((c) => ({ label: c, value: c }));
+const STATE_CATEGORIES = ["At Risk", "Challenged", "Healthy"];
 
 export default function MonitoringTable() {
-	const headers: string[] = ["Collateral", "Collateralization", "Expiration", "Challenged"];
-	const [tab, setTab] = useState<string>(headers[1]);
+	const headers: string[] = ["Collateral", "Price", "Health", "Challenged", "Expiration"];
+	const [tab, setTab] = useState<string>(headers[2]);
 	const [reverse, setReverse] = useState<boolean>(true);
 	const [list, setList] = useState<PositionQuery[]>([]);
 	const [searchQuery, setSearchQuery] = useState<string>("");
 	const [activeCategories, setActiveCategories] = useState<string[]>([]);
+	const [activeCustomCategories, setActiveCustomCategories] = useState<string[]>([]);
 	const [inMyWallet, setInMyWallet] = useState<boolean>(false);
 
 	const { address: walletAddress } = useAccount();
@@ -66,9 +68,29 @@ export default function MonitoringTable() {
 			)
 				return false;
 			if (inMyWallet && walletAddress && (walletBalanceMap[normalizeAddress(pos.collateral)] ?? 0n) === 0n) return false;
+			if (activeCustomCategories.length > 0) {
+				const collTokenPrice = coingecko[normalizeAddress(pos.collateral)]?.price?.usd || 1;
+				const zchfPrice = coingecko[normalizeAddress(pos.zchf)]?.price?.usd || 1;
+				const balance = parseInt(pos.collateralBalance) / 10 ** pos.collateralDecimals;
+				const balanceZCHF = (balance * collTokenPrice) / zchfPrice;
+				const liquidationZCHF = parseInt(pos.price) / 10 ** (36 - pos.collateralDecimals);
+				const liquidationPct = (balanceZCHF / (liquidationZCHF * balance)) * 100;
+				const positionChallenges = challenges.map[normalizeAddress(pos.position)] ?? [];
+				const hasActiveChallenges = positionChallenges.some((ch: ChallengesQueryItem) => ch.status === "Active");
+				const isAtRisk = liquidationPct < 110;
+				const isChallenged = hasActiveChallenges;
+				const isHealthy = liquidationPct > 120 && !hasActiveChallenges;
+				const matches = activeCustomCategories.some((s) => {
+					if (s === "At Risk") return isAtRisk;
+					if (s === "Challenged") return isChallenged;
+					if (s === "Healthy") return isHealthy;
+					return false;
+				});
+				if (!matches) return false;
+			}
 			return true;
 		});
-	}, [sorted, searchQuery, activeCategories, inMyWallet, walletAddress, walletBalanceMap]);
+	}, [sorted, searchQuery, activeCategories, activeCustomCategories, inMyWallet, walletAddress, walletBalanceMap, coingecko, challenges]);
 
 	useEffect(() => {
 		const idList = list.map((l) => l.position).join("_");
@@ -105,6 +127,9 @@ export default function MonitoringTable() {
 				filterOptions={FILTER_OPTIONS}
 				activeFilters={activeCategories}
 				onFiltersChange={setActiveCategories}
+				customCategories={STATE_CATEGORIES}
+				activeCustomCategories={activeCustomCategories}
+				onCustomCategoriesChange={setActiveCustomCategories}
 			/>
 			<TableBody>
 				{list.length == 0 ? (
@@ -138,6 +163,15 @@ function sortPositions(
 			return calc(b) - calc(a);
 		});
 	} else if (tab === headers[1]) {
+		// sort for price
+		sortingList.sort((a, b) => {
+			const calc = function (p: PositionQuery) {
+				const liqPrice: number = parseFloat(formatUnits(BigInt(p.price), 36 - p.collateralDecimals));
+				return liqPrice;
+			};
+			return calc(b) - calc(a);
+		});
+	} else if (tab === headers[2]) {
 		// sort for coll.
 		sortingList.sort((a, b) => {
 			const calc = function (p: PositionQuery) {
@@ -146,11 +180,6 @@ function sortPositions(
 				return price / liqPrice;
 			};
 			return calc(b) - calc(a);
-		});
-	} else if (tab === headers[2]) {
-		// sorft for Expiration
-		sortingList.sort((a, b) => {
-			return b.expiration - a.expiration;
 		});
 	} else if (tab === headers[3]) {
 		// sort for Challenged
@@ -167,6 +196,11 @@ function sortPositions(
 				return cs / size;
 			};
 			return calc(b) - calc(a);
+		});
+	} else if (tab === headers[4]) {
+		// sorft for Expiration
+		sortingList.sort((a, b) => {
+			return b.expiration - a.expiration;
 		});
 	}
 

--- a/components/PageMonitoring/StatRow.tsx
+++ b/components/PageMonitoring/StatRow.tsx
@@ -1,0 +1,8 @@
+export default function StatRow({ label, children }: { label: string; children: React.ReactNode }) {
+	return (
+		<div className="flex justify-between items-center py-0.5">
+			<span className="text-text-secondary text-sm">{label}</span>
+			<div className="text-text-primary text-sm font-medium text-right">{children}</div>
+		</div>
+	);
+}

--- a/components/Table/TableHead.tsx
+++ b/components/Table/TableHead.tsx
@@ -18,7 +18,7 @@ export default function TableHeader({ headers, subHeaders, actionCol, colSpan, t
 	};
 
 	return (
-		<div className="items-center justify-between rounded-t-lg bg-table-header-primary py-5 px-8 md:flex xl:px-12">
+		<div className="items-center justify-between rounded-t-lg bg-table-header-primary py-4 px-8 md:flex xl:px-12">
 			{/* @dev: this is desktop view */}
 			<div className={`max-md:hidden pl-8 flex-grow grid-cols-2 md:grid md:grid-cols-${colSpan || headers.length}`}>
 				{headers.map((header, i) => (

--- a/components/Table/TableHeadSearchable.tsx
+++ b/components/Table/TableHeadSearchable.tsx
@@ -24,6 +24,12 @@ interface Props {
 	activeFilters: string[];
 	onFiltersChange: (filters: string[]) => void;
 
+	// Custom categories filter
+	customCategories?: string[];
+	customCategoriesTitle?: string;
+	activeCustomCategories?: string[];
+	onCustomCategoriesChange?: (values: string[]) => void;
+
 	// Table column headers (same as TableHead)
 	headers: string[];
 	subHeaders?: string[];
@@ -44,6 +50,10 @@ export default function TableHeadSearchable({
 	filterOptions,
 	activeFilters,
 	onFiltersChange,
+	customCategories,
+	customCategoriesTitle = "State",
+	activeCustomCategories = [],
+	onCustomCategoriesChange,
 	headers,
 	subHeaders,
 	actionCol,
@@ -77,6 +87,17 @@ export default function TableHeadSearchable({
 			onFiltersChange([...activeFilters, value]);
 		}
 	};
+
+	const toggleCustomCategory = (value: string) => {
+		if (!onCustomCategoriesChange) return;
+		if (activeCustomCategories.includes(value)) {
+			onCustomCategoriesChange(activeCustomCategories.filter((f) => f !== value));
+		} else {
+			onCustomCategoriesChange([...activeCustomCategories, value]);
+		}
+	};
+
+	const totalActiveFilters = activeFilters.length + activeCustomCategories.length;
 
 	return (
 		<div className="rounded-t-lg bg-table-header-primary">
@@ -120,41 +141,71 @@ export default function TableHeadSearchable({
 						<button
 							onClick={() => setFilterOpen((prev) => !prev)}
 							className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-sm transition-colors ${
-								filterOpen || activeFilters.length > 0
+								filterOpen || totalActiveFilters > 0
 									? "border-button-default text-button-default bg-blue-50 dark:bg-blue-900/20"
 									: "dark:border-gray-600 text-text-secondary hover:bg-button-disabled"
 							}`}
 						>
 							<FontAwesomeIcon icon={faSlidersH} className="w-3.5 h-3.5" />
 							<span>Filter</span>
-							{activeFilters.length > 0 && (
+							{totalActiveFilters > 0 && (
 								<span className="ml-1 bg-button-default text-white text-xs rounded-full w-4 h-4 flex items-center justify-center">
-									{activeFilters.length}
+									{totalActiveFilters}
 								</span>
 							)}
 						</button>
 
 						{filterOpen && (
 							<div className="absolute right-0 top-full mt-2 z-50 w-52 rounded-lg bg-white dark:bg-gray-800 shadow-lg border border-gray-200 dark:border-gray-700 py-3">
-								<div className="px-4 pb-2">
-									<span className="text-xs font-semibold uppercase tracking-wider text-text-secondary">
-										Asset Categories
-									</span>
-								</div>
-								{filterOptions.map((opt) => (
-									<label
-										key={opt.value}
-										className="flex items-center gap-3 px-4 py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700"
-									>
-										<input
-											type="checkbox"
-											checked={activeFilters.includes(opt.value)}
-											onChange={() => toggleFilter(opt.value)}
-											className="w-4 h-4 rounded active:bg-button-default"
-										/>
-										<span className="text-sm text-text-primary">{opt.label}</span>
-									</label>
-								))}
+								{filterOptions.length > 0 && (
+									<>
+										<div className="px-4 pb-2">
+											<span className="text-xs font-semibold uppercase tracking-wider text-text-secondary">
+												Asset Categories
+											</span>
+										</div>
+										{filterOptions.map((opt) => (
+											<label
+												key={opt.value}
+												className="flex items-center gap-3 px-4 py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700"
+											>
+												<input
+													type="checkbox"
+													checked={activeFilters.includes(opt.value)}
+													onChange={() => toggleFilter(opt.value)}
+													className="w-4 h-4 rounded active:bg-button-default"
+												/>
+												<span className="text-sm text-text-primary">{opt.label}</span>
+											</label>
+										))}
+									</>
+								)}
+								{customCategories && customCategories.length > 0 && (
+									<>
+										{filterOptions.length > 0 && (
+											<div className="my-2 border-t border-gray-100 dark:border-gray-700" />
+										)}
+										<div className="px-4 pb-2">
+											<span className="text-xs font-semibold uppercase tracking-wider text-text-secondary">
+												{customCategoriesTitle}
+											</span>
+										</div>
+										{customCategories.map((category) => (
+											<label
+												key={category}
+												className="flex items-center gap-3 px-4 py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700"
+											>
+												<input
+													type="checkbox"
+													checked={activeCustomCategories.includes(category)}
+													onChange={() => toggleCustomCategory(category)}
+													className="w-4 h-4 rounded active:bg-button-default"
+												/>
+												<span className="text-sm text-text-primary">{category}</span>
+											</label>
+										))}
+									</>
+								)}
 							</div>
 						)}
 					</div>

--- a/components/Table/TableRow.tsx
+++ b/components/Table/TableRow.tsx
@@ -31,7 +31,7 @@ export default function TableRow({
 		<div
 			className={`${className} ${
 				paddingY ?? "py-4"
-			} bg-table-row-primary md:hover:bg-table-row-hover cursor-default px-8 xl:px-12 border-t border-table-row-hover last:rounded-b-lg duration-300`}
+			} bg-table-row-primary md:hover:bg-table-row-hover cursor-default px-8 xl:px-12 border-t border-table-header-secondary last:rounded-b-lg duration-300`}
 		>
 			<div className="flex sm:pl-8 flex-col justify-between gap-y-5 md:flex-row">
 				{/* @dev: this is desktop view */}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "frankencoin-dapp",
-	"version": "0.2.19",
+	"version": "0.2.20",
 	"private": false,
 	"license": "MIT",
 	"scripts": {

--- a/pages/mint/[address]/index.tsx
+++ b/pages/mint/[address]/index.tsx
@@ -519,7 +519,7 @@ export default function PositionBorrow({}) {
 					)}
 				</AppCard>
 
-				<div className="grid gap-4">
+				<div className="grid gap-4 mt-8">
 					{hasAlternatives && (
 						<AppCard>
 							<div className="text-lg font-bold text-center mt-3">Alternative Terms</div>

--- a/pages/mint/[address]/index.tsx
+++ b/pages/mint/[address]/index.tsx
@@ -16,6 +16,7 @@ import { useSelector } from "react-redux";
 import { RootState } from "../../../redux/redux.store";
 import { ADDRESS } from "@frankencoin/zchf";
 import AppLink from "@components/AppLink";
+import { useContractUrl } from "@hooks";
 import { useRouter as useNavigation } from "next/navigation";
 import { mainnet } from "viem/chains";
 import AppCard from "@components/AppCard";
@@ -177,6 +178,14 @@ export default function PositionBorrow({}) {
 	const now = Date.now();
 	const isPositionBlocked = position.start * 1000 > now || (position.start * 1000 < now && position.cooldown > now);
 
+	const positionExplorerUrl = useContractUrl(String(addressQuery));
+	const isCooldown = position.start * 1000 < now && position.cooldown > now;
+	const positionStatus = position.closed
+		? { label: "Closed", cls: "bg-red-500/20 text-red-400" }
+		: isCooldown
+		? { label: "Cooldown", cls: "bg-amber-500/20 text-amber-400" }
+		: { label: "Active", cls: "bg-green-500/20 text-green-400" };
+
 	const collKey = normalizeAddress(position.collateral);
 	const bestRatePos = bestInterestByCollateral[collKey];
 	const posEffectiveRate = position.annualInterestPPM / (1_000_000 - position.reserveContribution);
@@ -264,31 +273,28 @@ export default function PositionBorrow({}) {
 				<title>Frankencoin - Borrow</title>
 			</Head>
 
-			<AppTitle title="Borrow Frankencoins">
-				<div className="text-text-secondary">
-					Deposit{" "}
-					{DISCUSSIONS[position.collateral] ? (
-						<AppLink
-							className=""
-							label={`${position.collateralName} (${position.collateralSymbol})`}
-							href={DISCUSSIONS[position.collateral]}
-							external={true}
-						/>
-					) : (
-						<span>
-							{position.collateralName} ({position.collateralSymbol})
-						</span>
-					)}{" "}
-					as collateral and mint new Frankencoins against it, cloning the terms from position{" "}
-					<AppLink
-						className=""
-						label={shortenAddress(position.position)}
-						href={`/monitoring/${position.position}`}
-						external={false}
-					/>
-					.
-				</div>
-			</AppTitle>
+			<AppTitle
+				title={`${position.collateralName} (${position.collateralSymbol})`}
+				subtitle="Deposit collateral and borrow new Frankencoins"
+				badges={[
+					{ label: positionStatus.label, className: positionStatus.cls },
+					{ label: `V${position.version}`, className: "bg-blue-500/20 text-blue-400" },
+					...(position.isClone ? [{ label: "Clone", className: "bg-purple-500/20 text-purple-400" }] : []),
+				]}
+				actions={
+					<div className="flex flex-wrap gap-4 text-sm">
+						{DISCUSSIONS[normalizeAddress(position.collateral)] && (
+							<AppLink
+								className="text-right"
+								label={`Discussion`}
+								href={DISCUSSIONS[normalizeAddress(position.collateral)]}
+								external={true}
+							/>
+						)}
+						<AppLink className="text-right" label={`Reference`} href={`/monitoring/${position.position}`} external={false} />
+					</div>
+				}
+			/>
 
 			<div className="mt-8">
 				<section className="grid grid-cols-1 gap-4">

--- a/pages/mint/[address]/index.tsx
+++ b/pages/mint/[address]/index.tsx
@@ -4,6 +4,9 @@ import { useEffect, useState } from "react";
 import { formatUnits, parseUnits, erc20Abi, Address } from "viem";
 import TokenInput from "@components/Input/TokenInput";
 import ButtonSecondary from "@components/ButtonSecondary";
+import Button from "@components/Button";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faLink, faLinkSlash } from "@fortawesome/free-solid-svg-icons";
 import { useAccount, useBlockNumber } from "wagmi";
 import { readContract } from "wagmi/actions";
 import { formatCurrency, formatDateFromSecs, min, normalizeAddress, shortenAddress, toTimestamp, DISCUSSIONS } from "@utils";
@@ -36,6 +39,8 @@ export default function PositionBorrow({}) {
 	const [collAmount, setCollAmount] = useState(0n);
 	const [newPrice, setNewPrice] = useState(0n);
 	const [mintPrice, setMintPrice] = useState(0n);
+
+	const [linked, setLinked] = useState(true);
 
 	const [userAllowance, setUserAllowance] = useState(0n);
 	const [userAllowanceHelper, setUserAllowanceHelper] = useState(0n);
@@ -210,16 +215,28 @@ export default function PositionBorrow({}) {
 	const hasAlternatives = alternativeRows.some(({ pos, isBest }) => pos && !isBest);
 
 	const onChangeCollateral = (value: string) => {
-		setCollAmount(BigInt(value));
+		const newColl = BigInt(value);
+		setCollAmount(newColl);
+		if (linked && mintPrice > 0n) {
+			setAmount((newColl * mintPrice) / parseUnits("1", 18));
+		}
 	};
 
 	const onChangeAmount = (value: string) => {
-		setAmount(BigInt(value));
+		const newAmount = BigInt(value);
+		setAmount(newAmount);
+		if (linked && mintPrice > 0n) {
+			setCollAmount((newAmount * parseUnits("1", 18) + mintPrice - 1n) / mintPrice);
+		}
 	};
 
 	const onChangeLiqPrice = (v: bigint) => {
 		setNewPrice(v);
-		setMintPrice(v <= priceBigInt ? v : priceBigInt);
+		const effectivePrice = v <= priceBigInt ? v : priceBigInt;
+		setMintPrice(effectivePrice);
+		if (linked && collAmount > 0n) {
+			setAmount((collAmount * effectivePrice) / parseUnits("1", 18));
+		}
 	};
 
 	const onChangeExpiration = (value: Date | null) => {
@@ -308,6 +325,25 @@ export default function PositionBorrow({}) {
 							/>
 						</div>
 
+						<div className="py-1 text-center">
+							{linked ? (
+								<Button className="h-10 rounded-full" width="w-10" onClick={() => setLinked(false)}>
+									<FontAwesomeIcon icon={faLink} className="w-5 h-5" />
+								</Button>
+							) : (
+								<ButtonSecondary
+									className="h-10 rounded-full"
+									width="w-10"
+									onClick={() => {
+										setLinked(true);
+										if (mintPrice > 0n) setAmount((collAmount * mintPrice) / parseUnits("1", 18));
+									}}
+								>
+									<FontAwesomeIcon icon={faLinkSlash} className="w-5 h-5" />
+								</ButtonSecondary>
+							)}
+						</div>
+
 						<div className="grid md:grid-cols-1 gap-4">
 							<LiquidationSlider
 								label="Liquidation Price"
@@ -361,7 +397,7 @@ export default function PositionBorrow({}) {
 
 									<div className="mt-0 flex">
 										<div className="flex-1">
-											<span>Unused after cooldown</span>
+											<span>Usable after cooldown</span>
 										</div>
 										<div className="text-right">
 											{additionalMintable > 0n ? "-" : ""}

--- a/pages/mint/[address]/index.tsx
+++ b/pages/mint/[address]/index.tsx
@@ -239,7 +239,7 @@ export default function PositionBorrow({}) {
 	const priceDigit = 36 - position.collateralDecimals;
 
 	return (
-		<>
+		<div className="flex flex-col md:max-w-2xl mx-auto">
 			<Head>
 				<title>Frankencoin - Borrow</title>
 			</Head>
@@ -273,7 +273,7 @@ export default function PositionBorrow({}) {
 			<div className="mt-8">
 				<section className="grid grid-cols-1 gap-4">
 					<AppCard>
-						<div className="text-lg font-bold text-center mt-3">Borrow Frankencoins</div>
+						<div className="text-lg font-bold text-center">Borrow Frankencoins</div>
 						<div className="grid md:grid-cols-2 gap-4">
 							<TokenInput
 								label="Deposit"
@@ -305,7 +305,7 @@ export default function PositionBorrow({}) {
 							/>
 						</div>
 
-						<div className="grid md:grid-cols-2 gap-4">
+						<div className="grid md:grid-cols-1 gap-4">
 							<LiquidationSlider
 								label="Liquidation Price"
 								value={newPrice}
@@ -483,6 +483,6 @@ export default function PositionBorrow({}) {
 					</div>
 				</section>
 			</div>
-		</>
+		</div>
 	);
 }

--- a/pages/mint/[address]/index.tsx
+++ b/pages/mint/[address]/index.tsx
@@ -25,6 +25,7 @@ import LiquidationSlider from "@components/Input/LiquidationSlider";
 import { useBorrowPositions } from "../../../hooks/useBorrowPositions";
 import BorrowCloneAction from "@components/PageBorrow/BorrowCloneAction";
 import BorrowClonePriceAction from "@components/PageBorrow/BorrowClonePriceAction";
+import AppBox from "@components/AppBox";
 
 function toDate(time: bigint | number | string) {
 	return new Date(Number(BigInt(time)) * 1000);
@@ -240,8 +241,9 @@ export default function PositionBorrow({}) {
 	};
 
 	const onChangeLiqPrice = (v: bigint) => {
-		setNewPrice(v);
-		const effectivePrice = v <= priceBigInt ? v : priceBigInt;
+		const clamped = linked && v > priceBigInt ? priceBigInt : v;
+		setNewPrice(clamped);
+		const effectivePrice = clamped <= priceBigInt ? clamped : priceBigInt;
 		setMintPrice(effectivePrice);
 		if (linked && collAmount > 0n) {
 			setAmount((collAmount * effectivePrice) / parseUnits("1", 18));
@@ -283,6 +285,7 @@ export default function PositionBorrow({}) {
 				]}
 				actions={
 					<div className="flex flex-wrap gap-4 text-sm">
+						<AppLink className="text-right" label={`Reference`} href={`/monitoring/${position.position}`} external={false} />
 						{DISCUSSIONS[normalizeAddress(position.collateral)] && (
 							<AppLink
 								className="text-right"
@@ -291,131 +294,111 @@ export default function PositionBorrow({}) {
 								external={true}
 							/>
 						)}
-						<AppLink className="text-right" label={`Reference`} href={`/monitoring/${position.position}`} external={false} />
 					</div>
 				}
 			/>
 
 			<div className="mt-8">
-				<section className="grid grid-cols-1 gap-4">
-					<AppCard>
-						<div className="text-lg font-bold text-center">Borrow Frankencoins</div>
-						<div className="grid md:grid-cols-2 gap-4">
-							<TokenInput
-								label="Deposit"
-								max={userBalance >= minColl ? userBalance : undefined}
-								min={mintPrice > 0n ? (amount * parseUnits("1", 18) + mintPrice - 1n) / mintPrice : undefined}
-								reset={minColl}
-								digit={position.collateralDecimals}
-								onChange={onChangeCollateral}
-								error={errorColl}
-								placeholder="Amount"
-								value={String(collAmount)}
-								symbol={position.collateralSymbol}
-								limit={userBalance}
-								limitDigit={position.collateralDecimals}
-								limitLabel="Balance"
-							/>
-							<TokenInput
-								label="Mint now"
-								symbol="ZCHF"
-								value={amount.toString()}
-								onChange={onChangeAmount}
-								max={borrowingLimit}
-								onMax={() => setAmount(borrowingLimit)}
-								error={errorBorrow}
-								showButtons={true}
-								limit={borrowingLimit}
-								limitDigit={18}
-								limitLabel="Mintable"
-							/>
-						</div>
+				<AppCard>
+					<div className="text-lg font-bold text-center">Borrow Frankencoins</div>
+					<div className="grid md:grid-cols-2 gap-4">
+						<TokenInput
+							label="Deposit"
+							max={userBalance >= minColl ? userBalance : undefined}
+							min={mintPrice > 0n ? (amount * parseUnits("1", 18) + mintPrice - 1n) / mintPrice : undefined}
+							reset={minColl}
+							digit={position.collateralDecimals}
+							onChange={onChangeCollateral}
+							error={errorColl}
+							placeholder="Amount"
+							value={String(collAmount)}
+							symbol={position.collateralSymbol}
+							limit={userBalance}
+							limitDigit={position.collateralDecimals}
+							limitLabel="Balance"
+						/>
+						<TokenInput
+							label="Mint now"
+							symbol="ZCHF"
+							value={amount.toString()}
+							onChange={onChangeAmount}
+							max={borrowingLimit}
+							onMax={() => setAmount(borrowingLimit)}
+							error={errorBorrow}
+							showButtons={true}
+							limit={borrowingLimit}
+							limitDigit={18}
+							limitLabel="Mintable"
+						/>
+					</div>
 
-						<div className="py-1 text-center">
-							{linked ? (
-								<Button className="h-10 rounded-full" width="w-10" onClick={() => setLinked(false)}>
-									<FontAwesomeIcon icon={faLink} className="w-5 h-5" />
-								</Button>
-							) : (
-								<ButtonSecondary
-									className="h-10 rounded-full"
-									width="w-10"
-									onClick={() => {
-										setLinked(true);
-										if (mintPrice > 0n) setAmount((collAmount * mintPrice) / parseUnits("1", 18));
-									}}
-								>
-									<FontAwesomeIcon icon={faLinkSlash} className="w-5 h-5" />
-								</ButtonSecondary>
-							)}
-						</div>
+					<div className="-mt-4 text-center">
+						{linked ? (
+							<ButtonSecondary className="h-10 rounded-full" width="w-10" onClick={() => setLinked(false)}>
+								<FontAwesomeIcon icon={faLink} className="w-5 h-5" />
+							</ButtonSecondary>
+						) : (
+							<ButtonSecondary
+								className="h-10 rounded-full"
+								width="w-10"
+								onClick={() => {
+									setLinked(true);
+									const resetPrice = newPrice > priceBigInt ? priceBigInt : newPrice;
+									setNewPrice(resetPrice);
+									const effectivePrice = resetPrice <= priceBigInt ? resetPrice : priceBigInt;
+									setMintPrice(effectivePrice);
+									if (effectivePrice > 0n) setAmount((collAmount * effectivePrice) / parseUnits("1", 18));
+								}}
+							>
+								<FontAwesomeIcon icon={faLinkSlash} className="w-5 h-5" />
+							</ButtonSecondary>
+						)}
+					</div>
 
-						<div className="grid md:grid-cols-1 gap-4">
-							<LiquidationSlider
-								label="Liquidation Price"
-								value={newPrice}
-								digit={priceDigit}
-								sliderMin={parseUnits(String(collateralPriceZchf * 0.1), priceDigit)}
-								sliderMax={parseUnits(String(collateralPriceZchf), priceDigit)}
-								sliderSource={priceBigInt}
-								min={collAmount > 0n ? (amount * parseUnits("1", 18)) / collAmount : undefined}
-								max={parseUnits(String(collateralPriceZchf), priceDigit)}
-								reset={priceBigInt}
-								onChange={onChangeLiqPrice}
-								limit={ltvLimit}
-								limitDigit={6}
-								limitLabel="LTV"
-								limitUnit="%"
-								error={newPrice == 0n ? "Needs to be greater than zero" : ""}
-								warning={
-									newPrice > priceBigInt
-										? `Liquidation prices above the reference become effective after a 3-day cooldown. Afterwards, up to ${formatCurrency(
-												formatUnits(additionalMintable, 18)
-										  )} more ZCHF can be minted.`
-										: undefined
-								}
-							/>
+					<div className="grid md:grid-cols-1 gap-4">
+						<LiquidationSlider
+							label="Liquidation Price"
+							value={newPrice}
+							digit={priceDigit}
+							sliderMin={parseUnits(String(collateralPriceZchf * 0.1), priceDigit)}
+							sliderMax={parseUnits(String(collateralPriceZchf), priceDigit)}
+							sliderSource={priceBigInt}
+							min={collAmount > 0n ? (amount * parseUnits("1", 18)) / collAmount : undefined}
+							max={linked ? priceBigInt : parseUnits(String(collateralPriceZchf), priceDigit)}
+							reset={priceBigInt}
+							onChange={onChangeLiqPrice}
+							limit={ltvLimit}
+							limitDigit={6}
+							limitLabel="LTV"
+							limitUnit="%"
+							error={newPrice == 0n ? "Needs to be greater than zero" : ""}
+							warning={
+								newPrice > priceBigInt
+									? `Liquidation prices above the reference become effective after a 3-day cooldown. Afterwards, up to ${formatCurrency(
+											formatUnits(additionalMintable, 18)
+									  )} more ZCHF can be minted.`
+									: undefined
+							}
+						/>
 
-							<DateInput
-								label="Repay by"
-								value={expirationDate}
-								onChange={onChangeExpiration}
-								error={errorDate}
-								max={expirationMax}
-								tabs={["1M", "3M", "6M", "1Y", "Max"]}
-								tabDates={expirationTabDates}
-								tab={expirationTab}
-								onTab={onTabExpiration}
-							/>
-						</div>
+						<DateInput
+							label="Repay by"
+							value={expirationDate}
+							onChange={onChangeExpiration}
+							error={errorDate}
+							max={expirationMax}
+							tabs={["1M", "3M", "6M", "1Y", "Max"]}
+							tabDates={expirationTabDates}
+							tab={expirationTab}
+							onTab={onTabExpiration}
+						/>
+					</div>
 
-						<div className="flex-1 mb-4">
-							{newPrice > priceBigInt && (
-								<div className="text-amber-500">
-									<div className="flex">
-										<div className="flex-1">
-											<span>Mintable after cooldown</span>
-										</div>
-										<div className="text-right">
-											<span>{formatCurrency(formatUnits(mintableAtNewPrice, 18))} ZCHF</span>
-										</div>
-									</div>
-
-									<div className="mt-0 flex">
-										<div className="flex-1">
-											<span>Usable after cooldown</span>
-										</div>
-										<div className="text-right">
-											{additionalMintable > 0n ? "-" : ""}
-											<span>{formatCurrency(formatUnits(additionalMintable, 18))} ZCHF</span>
-										</div>
-									</div>
-								</div>
-							)}
-
-							<div className="mt-2 flex">
+					<div className="flex-1 mb-4 space-y-4">
+						<AppBox tight={true}>
+							<div className="flex">
 								<div className="flex-1 text-text-secondary">
-									<span>Mint now</span>
+									<span>{newPrice > priceBigInt ? "Minted now" : "Minted"}</span>
 									<span className="text-xs ml-1">(100%)</span>
 								</div>
 								<div className="text-right">
@@ -472,88 +455,113 @@ export default function PositionBorrow({}) {
 									<span>{formatCurrency(formatUnits(paidOutToWallet, 18))} ZCHF</span>
 								</div>
 							</div>
-						</div>
+						</AppBox>
 
-						<div className="mx-auto w-full flex-col">
-							{position.version == 2 && newPrice !== priceBigInt ? (
-								<BorrowClonePriceAction
-									position={position}
-									collAmount={collAmount}
-									requiredColl={requiredColl}
-									amount={amount}
-									expirationDate={expirationDate}
-									newPrice={newPrice}
-									userAllowance={userAllowanceHelper}
-									userBalance={userBalance}
-									disabled={!!errorColl || !!errorBorrow || isPositionBlocked}
-								/>
-							) : (
-								<BorrowCloneAction
-									position={position}
-									collAmount={collAmount}
-									requiredColl={requiredColl}
-									amount={amount}
-									expirationDate={expirationDate}
-									userAllowance={userAllowance}
-									userBalance={userBalance}
-									disabled={!!errorColl || !!errorBorrow || isPositionBlocked}
-								/>
-							)}
-						</div>
-
-						{isPositionBlocked && (
-							<div className="flex my-2 px-2 text-amber-500">
-								{position.start * 1000 > now
-									? "This position is pending governance approval."
-									: "This position is in a cooldown period."}
-							</div>
-						)}
-					</AppCard>
-
-					<div className="grid gap-4">
-						{hasAlternatives && (
-							<AppCard>
-								<div className="text-lg font-bold text-center mt-3">Alternative Terms</div>
-								<div className="flex-1 mt-4">
-									<div className="grid grid-cols-3 text-xs text-text-secondary pb-1 border-b border-gray-200 mb-1">
-										<div>Term</div>
-										<div className="text-center">Value</div>
-										<div className="text-right">Best</div>
+						{newPrice > priceBigInt && (
+							<AppBox tight={true}>
+								<div className="text-amber-500">
+									<div className="flex">
+										<div className="flex-1">
+											<span>Mintable after cooldown</span>
+										</div>
+										<div className="text-right">
+											<span>{formatCurrency(formatUnits(mintableAtNewPrice, 18))} ZCHF</span>
+										</div>
 									</div>
-									{alternativeRows.map(({ label, pos, value, isBest }) => {
-										if (!pos) return null;
-										return (
-											<div
-												key={label}
-												className={`grid grid-cols-3 py-2 text-sm border-b border-gray-100 last:border-0 ${
-													isBest ? "text-text-secondary" : "cursor-pointer"
-												}`}
-												onClick={() => !isBest && navigate.push(`/mint/${pos.position}`)}
-											>
-												<div className="text-text-secondary">{label}</div>
-												<div className="text-center font-medium text-text-primary">{value}</div>
-												<div className="text-right">
-													{isBest ? (
-														<span className="font-bold text-green-500">✓</span>
-													) : (
-														<span className="inline-block text-xs px-2 py-0.5 rounded-full bg-button-default hover:bg-button-hover text-white font-medium">
-															Select
-														</span>
-													)}
-												</div>
-											</div>
-										);
-									})}
+
+									<div className="mt-0 flex">
+										<div className="flex-1">
+											<span>Available after cooldown</span>
+										</div>
+										<div className="text-right">
+											{additionalMintable > 0n ? "-" : ""}
+											<span>{formatCurrency(formatUnits(additionalMintable, 18))} ZCHF</span>
+										</div>
+									</div>
 								</div>
-								<div className="mt-2">
-									<ButtonSecondary onClick={() => navigate.push(`/mint/create?source=${addressQuery}`)}>
-										Need different terms?
-									</ButtonSecondary>
-								</div>
-							</AppCard>
+							</AppBox>
 						)}
 					</div>
-				</section>
+
+					<div className="mx-auto w-full flex-col">
+						{position.version == 2 && newPrice !== priceBigInt ? (
+							<BorrowClonePriceAction
+								position={position}
+								collAmount={collAmount}
+								requiredColl={requiredColl}
+								amount={amount}
+								expirationDate={expirationDate}
+								newPrice={newPrice}
+								userAllowance={userAllowanceHelper}
+								userBalance={userBalance}
+								disabled={!!errorColl || !!errorBorrow || isPositionBlocked}
+							/>
+						) : (
+							<BorrowCloneAction
+								position={position}
+								collAmount={collAmount}
+								requiredColl={requiredColl}
+								amount={amount}
+								expirationDate={expirationDate}
+								userAllowance={userAllowance}
+								userBalance={userBalance}
+								disabled={!!errorColl || !!errorBorrow || isPositionBlocked}
+							/>
+						)}
+					</div>
+
+					{isPositionBlocked && (
+						<div className="flex my-2 px-2 text-amber-500">
+							{position.start * 1000 > now
+								? "This position is pending governance approval."
+								: "This position is in a cooldown period."}
+						</div>
+					)}
+				</AppCard>
+
+				<div className="grid gap-4">
+					{hasAlternatives && (
+						<AppCard>
+							<div className="text-lg font-bold text-center mt-3">Alternative Terms</div>
+							<div className="flex-1 mt-4">
+								<div className="grid grid-cols-3 text-xs text-text-secondary pb-1 border-b border-gray-200 mb-1">
+									<div>Term</div>
+									<div className="text-center">Value</div>
+									<div className="text-right">Best</div>
+								</div>
+								{alternativeRows.map(({ label, pos, value, isBest }) => {
+									if (!pos) return null;
+									return (
+										<div
+											key={label}
+											className={`grid grid-cols-3 py-2 text-sm border-b border-gray-100 last:border-0 ${
+												isBest ? "text-text-secondary" : "cursor-pointer"
+											}`}
+											onClick={() => !isBest && navigate.push(`/mint/${pos.position}`)}
+										>
+											<div className="text-text-secondary">{label}</div>
+											<div className="text-center font-medium text-text-primary">{value}</div>
+											<div className="text-right">
+												{isBest ? (
+													<span className="font-bold text-green-500">✓</span>
+												) : (
+													<span className="inline-block text-xs px-2 py-0.5 rounded-full bg-button-default hover:bg-button-hover text-white font-medium">
+														Select
+													</span>
+												)}
+											</div>
+										</div>
+									);
+								})}
+							</div>
+							<div className="mt-2">
+								<ButtonSecondary onClick={() => navigate.push(`/mint/create?source=${addressQuery}`)}>
+									Need different terms?
+								</ButtonSecondary>
+							</div>
+						</AppCard>
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/pages/mint/[address]/index.tsx
+++ b/pages/mint/[address]/index.tsx
@@ -120,10 +120,12 @@ export default function PositionBorrow({}) {
 	if (!position) return null;
 
 	const priceBigInt = BigInt(position.price);
-	const priceFloat = parseFloat(formatUnits(priceBigInt, 36 - position.collateralDecimals));
+	const priceDigit = 36 - position.collateralDecimals;
+	const priceFloat = parseFloat(formatUnits(priceBigInt, priceDigit));
 	const collateralPriceZchf = prices[normalizeAddress(position.collateral)].price.chf || 1;
 	const reserve = position.reserveContribution / 10 ** 6;
 	const effectiveLTV = (priceFloat * (1 - reserve)) / collateralPriceZchf;
+	const ltvLimit = parseUnits(Math.max(0, (Number(formatUnits(newPrice, priceDigit)) / collateralPriceZchf) * 100).toFixed(6), 6);
 	const effectiveInterest = position.annualInterestPPM / 10 ** 6 / (1 - reserve);
 
 	const requiredColl = collAmount > BigInt(position.minimumCollateral) ? collAmount : BigInt(position.minimumCollateral);
@@ -156,6 +158,9 @@ export default function PositionBorrow({}) {
 	const paidOutToWallet = amount - borrowersReserveContribution - fees;
 	const availableByCollateralPrice = (collAmount * mintPrice) / parseUnits("1", 18);
 	const borrowingLimit = min(availableAmount, availableByCollateralPrice);
+	const mintableAtNewPrice = min((collAmount * newPrice) / parseUnits("1", 18), availableAmount);
+	const additionalMintable = mintableAtNewPrice > amount ? mintableAtNewPrice - amount : 0n;
+	const additionalMintableReserve = (BigInt(position.reserveContribution) * additionalMintable) / 1_000_000n;
 
 	const errorBorrow =
 		amount > availableAmount
@@ -236,8 +241,6 @@ export default function PositionBorrow({}) {
 		onChangeExpiration(expirationTabDates[t] ?? expirationMax);
 	};
 
-	const priceDigit = 36 - position.collateralDecimals;
-
 	return (
 		<div className="flex flex-col md:max-w-2xl mx-auto">
 			<Head>
@@ -291,7 +294,7 @@ export default function PositionBorrow({}) {
 								limitLabel="Balance"
 							/>
 							<TokenInput
-								label="Mint"
+								label="Mint now"
 								symbol="ZCHF"
 								value={amount.toString()}
 								onChange={onChangeAmount}
@@ -301,7 +304,7 @@ export default function PositionBorrow({}) {
 								showButtons={true}
 								limit={borrowingLimit}
 								limitDigit={18}
-								limitLabel="Available"
+								limitLabel="Mintable"
 							/>
 						</div>
 
@@ -317,13 +320,16 @@ export default function PositionBorrow({}) {
 								max={parseUnits(String(collateralPriceZchf), priceDigit)}
 								reset={priceBigInt}
 								onChange={onChangeLiqPrice}
-								limit={parseUnits(String(collateralPriceZchf), 18)}
-								limitDigit={18}
-								limitLabel="Market"
+								limit={ltvLimit}
+								limitDigit={6}
+								limitLabel="LTV"
+								limitUnit="%"
 								error={newPrice == 0n ? "Needs to be greater than zero" : ""}
 								warning={
 									newPrice > priceBigInt
-										? "Liquidation prices above the reference become effective after a 3-day cooldown."
+										? `Liquidation prices above the reference become effective after a 3-day cooldown. Afterwards, up to ${formatCurrency(
+												formatUnits(additionalMintable, 18)
+										  )} more ZCHF can be minted.`
 										: undefined
 								}
 							/>
@@ -342,9 +348,33 @@ export default function PositionBorrow({}) {
 						</div>
 
 						<div className="flex-1 mb-4">
-							<div className="flex">
+							{newPrice > priceBigInt && (
+								<div className="text-amber-500">
+									<div className="flex">
+										<div className="flex-1">
+											<span>Mintable after cooldown</span>
+										</div>
+										<div className="text-right">
+											<span>{formatCurrency(formatUnits(mintableAtNewPrice, 18))} ZCHF</span>
+										</div>
+									</div>
+
+									<div className="mt-0 flex">
+										<div className="flex-1">
+											<span>Unused after cooldown</span>
+										</div>
+										<div className="text-right">
+											{additionalMintable > 0n ? "-" : ""}
+											<span>{formatCurrency(formatUnits(additionalMintable, 18))} ZCHF</span>
+										</div>
+									</div>
+								</div>
+							)}
+
+							<div className="mt-2 flex">
 								<div className="flex-1 text-text-secondary">
-									<span>Minted</span>
+									<span>Mint now</span>
+									<span className="text-xs ml-1">(100%)</span>
 								</div>
 								<div className="text-right">
 									<span>{formatCurrency(formatUnits(amount, 18))} ZCHF</span>
@@ -364,7 +394,7 @@ export default function PositionBorrow({}) {
 								</div>
 							</div>
 
-							<div className="mt-1 flex">
+							<div className="mt-2 flex">
 								<div className="flex-1 text-text-secondary">
 									<span>To be repaid in the end</span>
 									<span className="text-xs ml-1">({formatCurrency(100 - position.reserveContribution / 10000)}%)</span>

--- a/pages/monitoring/[address]/index.tsx
+++ b/pages/monitoring/[address]/index.tsx
@@ -1,27 +1,26 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
-import AppBox from "@components/AppBox";
-import DisplayLabel from "@components/DisplayLabel";
-import DisplayAmount from "@components/DisplayAmount";
-import { formatDateTime, normalizeAddress, shortenAddress } from "@utils";
+import AppCard from "@components/AppCard";
+import AppLink from "@components/AppLink";
+import AppTitle from "@components/AppTitle";
+import MintingUpdatesTable from "@components/PageMonitoring/MintingUpdatesTable";
+import AuctionCard from "@components/PageMonitoring/AuctionCard";
+import StatRow from "@components/PageMonitoring/StatRow";
+import { formatCurrency, formatDateTime, normalizeAddress, shortenAddress, DISCUSSIONS } from "@utils";
 import { Address, formatUnits, zeroAddress } from "viem";
 import { useContractUrl } from "@hooks";
 import { useSelector } from "react-redux";
 import { RootState } from "../../../redux/redux.store";
-import { CONFIG, WAGMI_CONFIG } from "../../../app.config";
+import { FRANKENCOIN_API_CLIENT, WAGMI_CONFIG } from "../../../app.config";
 import { useEffect, useState } from "react";
 import { readContract } from "wagmi/actions";
-import { ChallengesQueryItem, PositionQuery } from "@frankencoin/api";
-import { useRouter as useNavigation } from "next/navigation";
-import Button from "@components/Button";
+import { ApiMintingUpdateListing, MintingUpdateQuery } from "@frankencoin/api";
 import { ADDRESS, FrankencoinABI } from "@frankencoin/zchf";
-import DisplayOutputAlignedRight from "@components/DisplayOutputAlignedRight";
-import AppLink from "@components/AppLink";
 import { mainnet } from "viem/chains";
-import AppCard from "@components/AppCard";
 
 export default function PositionDetail() {
 	const [reserve, setReserve] = useState<bigint>(0n);
+	const [mintingUpdates, setMintingUpdates] = useState<MintingUpdateQuery[]>([]);
 
 	const router = useRouter();
 	const address = router.query.address as Address;
@@ -29,212 +28,198 @@ export default function PositionDetail() {
 
 	const positions = useSelector((state: RootState) => state.positions.list.list);
 	const challengesPositions = useSelector((state: RootState) => state.challenges.positions);
+	const prices = useSelector((state: RootState) => state.prices.coingecko);
 
 	const position = positions.find((p) => normalizeAddress(p.position) === normalizeAddress(address));
 	const challengesActive = (challengesPositions.map[normalizeAddress(address)] || []).filter((c) => c.status === "Active");
 
 	const positionExplorerUrl = useContractUrl(String(address));
-	const ownerExplorerLink = useContractUrl(position?.owner || zeroAddress);
 	const myPosLink = `/mypositions?address=${position?.owner || zeroAddress}`;
-	const parentLink = `/monitoring/${(position?.version == 2 && position?.parent) || zeroAddress}`;
 
 	useEffect(() => {
 		if (!position) return;
 
-		const fetchAsync = async function () {
-			const data = await readContract(WAGMI_CONFIG, {
+		const fetchAsync = async () => {
+			const reserveData = await readContract(WAGMI_CONFIG, {
 				address: position.zchf,
 				chainId,
 				abi: FrankencoinABI,
 				functionName: "calculateAssignedReserve",
 				args: [BigInt(position.minted), position.reserveContribution],
 			});
+			setReserve(reserveData);
 
-			setReserve(data);
+			const updates = await FRANKENCOIN_API_CLIENT.get<ApiMintingUpdateListing>(
+				`/positions/mintingupdates/position/${position.version}/${normalizeAddress(position.position)}`
+			);
+			setMintingUpdates(updates.data.list ?? []);
 		};
 
 		fetchAsync();
 	}, [position, chainId]);
 
-	if (!position) return;
+	if (!position) return null;
 
 	const isSubjectToCooldown = () => {
 		const now = BigInt(Math.floor(Date.now() / 1000));
 		return now < position.cooldown && position.cooldown < 32508005122n;
 	};
 
-	const parentAddressInfo = (): string => {
-		if (position.version == 1) return "Not available for V1";
-		else if (position.version == 2) {
-			if (position.isOriginal) return "-";
-			else return shortenAddress(position.parent);
-		} else return "-";
+	const priceDigit = 36 - position.collateralDecimals;
+	const liqPriceFloat = parseFloat(formatUnits(BigInt(position.price), priceDigit));
+	const marketPriceChf = prices[normalizeAddress(position.collateral)]?.price?.chf || 0;
+	const nominalLTV = marketPriceChf > 0 ? (liqPriceFloat / marketPriceChf) * 100 : 0;
+
+	const originalInfo =
+		!position.isOriginal && position.original
+			? { label: shortenAddress(position.original), href: `/monitoring/${position.original}` }
+			: null;
+
+	const statusBadge = () => {
+		if (position.closed) return { label: "Closed", cls: "bg-red-500/20 text-red-400" };
+		if (isSubjectToCooldown()) return { label: "Cooldown", cls: "bg-amber-500/20 text-amber-400" };
+		return { label: "Active", cls: "bg-green-500/20 text-green-400" };
 	};
+	const status = statusBadge();
 
 	return (
 		<>
 			<Head>
 				<title>Frankencoin - Position Details</title>
 			</Head>
-			<div className="md:mt-8">
-				<section className="grid grid-cols-1 md:grid-cols-2 gap-4">
-					<AppCard>
-						<div className="text-lg font-bold text-center">Position Details</div>
 
-						<div className="grid grid-cols-1 md:grid-cols-2 gap-2 lg:col-span-2">
-							<AppBox>
-								<DisplayLabel label="Minted Total" />
-								<DisplayAmount amount={BigInt(position.minted)} currency="ZCHF" address={ADDRESS[chainId].frankencoin} />
-							</AppBox>
-							<AppBox>
-								<DisplayLabel label="Collateral" />
-								<DisplayAmount
-									amount={BigInt(position.collateralBalance)}
-									currency={position.collateralSymbol}
-									digits={position.collateralDecimals}
-									address={position.collateral}
-								/>
-							</AppBox>
-							<AppBox>
-								<DisplayLabel label="Liquidation Price" />
-								<DisplayAmount
-									amount={BigInt(position.price)}
-									currency={"ZCHF"}
-									digits={36 - position.collateralDecimals}
-									address={ADDRESS[chainId].frankencoin}
-								/>
-							</AppBox>
-							<AppBox>
-								<DisplayLabel label="Retained Reserve" />
-								<DisplayAmount amount={reserve} currency={"ZCHF"} address={ADDRESS[chainId].frankencoin} />
-							</AppBox>
-							<AppBox>
-								<DisplayLabel label="Limit" />
-								<DisplayAmount
-									amount={BigInt(position.limitForClones)}
-									currency={"ZCHF"}
-									address={ADDRESS[chainId].frankencoin}
-								/>
-							</AppBox>
-							<AppBox>
-								<DisplayLabel label="Available for Clones" />
-								<DisplayAmount
-									amount={BigInt(position.availableForClones)}
-									currency={"ZCHF"}
-									address={ADDRESS[chainId].frankencoin}
-								/>
-							</AppBox>
-							<AppBox>
-								<DisplayLabel label="Minimum Collateral" />
-								<DisplayAmount
-									amount={BigInt(position.minimumCollateral)}
-									currency={position.collateralSymbol}
-									digits={position.collateralDecimals}
-									address={position.collateral}
-								/>
-							</AppBox>
-							<AppBox>
-								<DisplayLabel label="Auction Duration" />
-								<DisplayOutputAlignedRight amount={position.challengePeriod / 60 / 60} unit={"hours"} />
-							</AppBox>
-							<AppBox>
-								<DisplayLabel label="Owner" />
-								<AppLink label={shortenAddress(position.owner)} href={myPosLink} external={false} />
-							</AppBox>
-							<AppBox>
-								<DisplayLabel label="Reserve Requirement" />
-								<DisplayOutputAlignedRight amount={BigInt(position.reserveContribution / 100)} digits={2} unit={"%"} />
-							</AppBox>
-							<AppBox>
-								<DisplayLabel label="Annual Interest" />
-								<DisplayOutputAlignedRight amount={BigInt(position.annualInterestPPM / 100)} digits={2} unit={"%"} />
-							</AppBox>
-							<AppBox>
-								<DisplayLabel label="Start Date" />
-								<DisplayOutputAlignedRight
-									output={formatDateTime(position.isOriginal ? position.start : position.created)}
-								/>
-							</AppBox>
-							<AppBox>
-								<DisplayLabel label="Expiration Date" />
-								<DisplayOutputAlignedRight output={position.closed ? "Closed" : formatDateTime(position.expiration)} />
-							</AppBox>
-							<AppBox>
-								<DisplayLabel label="Smart Contract" />
-								<AppLink label={shortenAddress(position.position)} href={positionExplorerUrl} external={true} />
-							</AppBox>
-							<AppBox>
-								<DisplayLabel label="Parent Position" />
-								<AppLink label={parentAddressInfo()} href={parentLink} external={false} />
-							</AppBox>
+			<div className="flex flex-col gap-4">
+				{/* Header */}
+				<AppTitle
+					title={`${position.collateralName} (${position.collateralSymbol})`}
+					subtitle={`Position details of ${position.position}.`}
+					badges={[
+						{ label: status.label, className: status.cls },
+						{ label: `V${position.version}`, className: "bg-blue-500/20 text-blue-400" },
+						...(position.isClone ? [{ label: "Clone", className: "bg-purple-500/20 text-purple-400" }] : []),
+					]}
+					actions={
+						<div className="flex flex-wrap gap-4 text-sm">
+							{DISCUSSIONS[normalizeAddress(position.collateral)] && (
+								<AppLink label={`Discussion`} href={DISCUSSIONS[normalizeAddress(position.collateral)]} external={true} />
+							)}
+							<AppLink label="Contract" href={positionExplorerUrl} external={true} />
+							<AppLink label={`Owner: ${shortenAddress(position.owner)}`} href={myPosLink} external={false} />
+							{originalInfo && (
+								<AppLink label={`Original: ${originalInfo.label}`} href={originalInfo.href} external={false} />
+							)}
+						</div>
+					}
+				/>
+
+				{/* Detail cards – 2-col desktop, 1-col mobile */}
+				<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<AppCard>
+						<div className="gap-2">
+							<div className="text-base font-bold mb-1">Mint Details</div>
+							<StatRow label="Minted">{formatCurrency(formatUnits(BigInt(position.minted), 18))} ZCHF</StatRow>
+							<StatRow label="Retained Reserve">{formatCurrency(formatUnits(reserve, 18))} ZCHF</StatRow>
+							<StatRow label="Available for Clones">
+								{formatCurrency(formatUnits(BigInt(position.availableForClones), 18))} ZCHF
+							</StatRow>
+							<StatRow label="Limit">{formatCurrency(formatUnits(BigInt(position.limitForClones), 18))} ZCHF</StatRow>
 						</div>
 					</AppCard>
 
-					<div>
-						{isSubjectToCooldown() && (
-							<AppCard>
-								<div className="text-lg font-bold text-center">Cooldown</div>
-								<AppBox className="flex-1 mt-4">
-									<p>
-										This position is subject to a cooldown period that ends on {formatDateTime(position.cooldown)} as
-										its owner has recently increased the applicable liquidation price. The cooldown period gives other
-										users an opportunity to challenge the position before additional Frankencoins can be minted.
-									</p>
-								</AppBox>
-							</AppCard>
-						)}
+					<AppCard>
+						<div className="gap-2">
+							<div className="text-base font-bold mb-1">Collateral Details</div>
+							<StatRow label="Balance">
+								{formatCurrency(formatUnits(BigInt(position.collateralBalance), position.collateralDecimals))}{" "}
+								{position.collateralSymbol}
+							</StatRow>
+							<StatRow label="Min. Collateral">
+								{formatCurrency(formatUnits(BigInt(position.minimumCollateral), position.collateralDecimals))}{" "}
+								{position.collateralSymbol}
+							</StatRow>
+							<StatRow label="Liquidation Price">
+								{formatCurrency(formatUnits(BigInt(position.price), priceDigit))} ZCHF
+							</StatRow>
+							<StatRow label="Nominal LTV">
+								<span className={nominalLTV > 90 ? "text-red-400" : nominalLTV > 80 ? "text-amber-400" : "text-green-400"}>
+									{formatCurrency(nominalLTV, 2, 2)}%
+								</span>
+							</StatRow>
+						</div>
+					</AppCard>
 
+					<AppCard>
+						<div className="gap-2">
+							<div className="text-base font-bold mb-1">Terms</div>
+							<StatRow label="Annual Interest">{formatCurrency(position.annualInterestPPM / 10000, 2, 2)}%</StatRow>
+							<StatRow label="Reserve Requirement">{formatCurrency(position.reserveContribution / 10000, 2, 2)}%</StatRow>
+							<StatRow label="Auction Duration">{position.challengePeriod / 3600} hours</StatRow>
+						</div>
+					</AppCard>
+
+					<AppCard>
+						<div className="gap-2">
+							<div className="text-base font-bold mb-1">Lifecycle</div>
+							<StatRow label="Start">{formatDateTime(position.isOriginal ? position.start : position.created)}</StatRow>
+							<StatRow label="Expiration">
+								<span className={position.closed ? "text-red-400" : ""}>
+									{position.closed ? "Closed" : formatDateTime(position.expiration)}
+								</span>
+							</StatRow>
+							{isSubjectToCooldown() && (
+								<StatRow label="Cooldown Until">
+									<span className="text-amber-400">{formatDateTime(position.cooldown)}</span>
+								</StatRow>
+							)}
+						</div>
+					</AppCard>
+
+					{isSubjectToCooldown() && (
 						<AppCard>
-							<div className="text-lg font-bold text-center">Active Challenges ({challengesActive.length})</div>
+							<div className="text-base font-bold text-amber-400 mb-1">Cooldown Active</div>
+							<p className="text-text-secondary text-sm leading-relaxed">
+								The owner recently raised the liquidation price. This position is in a cooldown period until{" "}
+								<span className="text-text-primary font-medium">{formatDateTime(position.cooldown)}</span>. During this time
+								the position can be challenged before additional ZCHF can be minted.
+							</p>
+						</AppCard>
+					)}
 
-							{challengesActive.map((c, idx) => (
-								<ActiveAuctionsRow key={c.id || `ActiveAuctionsRow_${idx}`} position={position} challenge={c} />
-							))}
-							{challengesActive.length === 0 ? <ActiveAuctionsRowEmpty /> : null}
+					<div className={isSubjectToCooldown() ? "" : "md:col-span-2"}>
+						<AppCard>
+							<AppTitle
+								className="!pt-0"
+								classNameTitle="text-base"
+								title="Active Auctions"
+								badges={[
+									{
+										label: String(challengesActive.length),
+										className:
+											challengesActive.length > 0
+												? "bg-red-500/20 text-red-400"
+												: "bg-card-content-primary text-text-secondary",
+									},
+								]}
+							/>
+							{challengesActive.length === 0 ? (
+								<p className="text-text-secondary text-sm">This position is currently not being challenged.</p>
+							) : (
+								<div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+									{challengesActive.map((c, idx) => (
+										<AuctionCard key={c.id || `auction_${idx}`} position={position} challenge={c} />
+									))}
+								</div>
+							)}
 						</AppCard>
 					</div>
-				</section>
+				</div>
+
+				{/* Minting History – full width */}
+				<div>
+					<div className="text-lg font-bold mb-2 px-2">Minting History</div>
+					<MintingUpdatesTable updates={mintingUpdates} position={position} />
+				</div>
 			</div>
 		</>
-	);
-}
-
-interface Props {
-	position: PositionQuery;
-	challenge: ChallengesQueryItem;
-}
-
-function ActiveAuctionsRow({ position, challenge }: Props) {
-	const navigate = useNavigation();
-
-	const beginning: number = parseFloat(formatUnits(challenge.size, position.collateralDecimals));
-	const remaining: number = parseFloat(formatUnits(challenge.size - challenge.filledSize, position.collateralDecimals));
-	return (
-		<AppBox className="flex-1 mt-4">
-			<AppBox className="col-span-3">
-				<DisplayLabel label="Remaining Size" />
-				<DisplayAmount
-					amount={BigInt(challenge.size - challenge.filledSize)}
-					digits={position.collateralDecimals}
-					currency={position.collateralSymbol}
-					address={position.collateral}
-				/>
-
-				<Button
-					className="h-10 mt-6"
-					onClick={() => navigate.push(`/monitoring/${normalizeAddress(challenge.position)}/auction/${challenge.number}`)}
-				>
-					Bid
-				</Button>
-			</AppBox>
-		</AppBox>
-	);
-}
-
-function ActiveAuctionsRowEmpty() {
-	return (
-		<AppBox className="flex-1 mt-4">
-			<p>This position is currently not being challenged.</p>
-		</AppBox>
 	);
 }

--- a/pages/monitoring/[address]/index.tsx
+++ b/pages/monitoring/[address]/index.tsx
@@ -216,9 +216,13 @@ export default function PositionDetail() {
 					</div>
 				</div>
 
-				{/* Minting History – full width */}
+				{/* Position History – full width */}
 				<div>
-					<div className="text-lg font-bold mb-2 px-2">Minting History</div>
+					<AppTitle
+						title="Position History"
+						subtitle="A chronological record of all price, minting and collateral adjustments for this position."
+						className="pb-4"
+					/>
 					<MintingUpdatesTable updates={mintingUpdates} position={position} />
 				</div>
 			</div>

--- a/pages/monitoring/[address]/index.tsx
+++ b/pages/monitoring/[address]/index.tsx
@@ -176,12 +176,14 @@ export default function PositionDetail() {
 
 					{isSubjectToCooldown() && (
 						<AppCard>
-							<div className="text-base font-bold text-amber-400 mb-1">Cooldown Active</div>
-							<p className="text-text-secondary text-sm leading-relaxed">
-								The owner recently raised the liquidation price. This position is in a cooldown period until{" "}
-								<span className="text-text-primary font-medium">{formatDateTime(position.cooldown)}</span>. During this time
-								the position can be challenged before additional ZCHF can be minted.
-							</p>
+							<div className="gap-2">
+								<div className="text-base font-bold text-amber-400 mb-1">Cooldown Active</div>
+								<p className="text-text-secondary text-sm leading-relaxed">
+									The owner recently raised the liquidation price. This position is in a cooldown period until{" "}
+									<span className="text-text-primary font-medium">{formatDateTime(position.cooldown)}</span>. During this
+									time the position can be challenged before additional ZCHF can be minted.
+								</p>
+							</div>
 						</AppCard>
 					)}
 

--- a/pages/monitoring/[address]/index.tsx
+++ b/pages/monitoring/[address]/index.tsx
@@ -100,14 +100,12 @@ export default function PositionDetail() {
 					]}
 					actions={
 						<div className="flex flex-wrap gap-4 text-sm">
+							<AppLink label={`Owner`} href={myPosLink} external={false} />
+							{originalInfo && <AppLink label={`Original`} href={originalInfo.href} external={false} />}
 							{DISCUSSIONS[normalizeAddress(position.collateral)] && (
 								<AppLink label={`Discussion`} href={DISCUSSIONS[normalizeAddress(position.collateral)]} external={true} />
 							)}
 							<AppLink label="Contract" href={positionExplorerUrl} external={true} />
-							<AppLink label={`Owner: ${shortenAddress(position.owner)}`} href={myPosLink} external={false} />
-							{originalInfo && (
-								<AppLink label={`Original: ${originalInfo.label}`} href={originalInfo.href} external={false} />
-							)}
 						</div>
 					}
 				/>

--- a/pages/monitoring/index.tsx
+++ b/pages/monitoring/index.tsx
@@ -126,9 +126,16 @@ export default function Positions() {
 					{
 						label: "Collateral Overview",
 						content: (
-							<div className="mt-8">
-								<CollateralOverviewTable />
-							</div>
+							<>
+								<AppTitle title={`Accepted Collateral Assets`}>
+									<div className="text-text-secondary">
+										An overview of all collateral types currently accepted by the Frankencoin protocol.
+									</div>
+								</AppTitle>
+								<div className="mt-8">
+									<CollateralOverviewTable />
+								</div>
+							</>
 						),
 					},
 				]}

--- a/pages/monitoring/index.tsx
+++ b/pages/monitoring/index.tsx
@@ -1,15 +1,25 @@
 import Head from "next/head";
 import MonitoringTable from "@components/PageMonitoring/MonitoringTable";
 import { useEffect } from "react";
-import { store } from "../../redux/redux.store";
+import { RootState, store } from "../../redux/redux.store";
 import { fetchPositionsList } from "../../redux/slices/positions.slice";
 import { fetchMarketChart } from "../../redux/slices/prices.slice";
 import ChallengesTable from "@components/PageChallenges/ChallengesTable";
 import AppTitle from "@components/AppTitle";
 import AppLink from "@components/AppLink";
 import MarketChart from "@components/PageEcoSystem/MarketChart";
+import { useSelector } from "react-redux";
+import PageTabInput from "@components/Input/PageTabInput";
+import AppHeroSteps from "@components/AppHeroSteps";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faAward, faGavel, faMoneyBill, faTrophy } from "@fortawesome/free-solid-svg-icons";
+import FrankencoinAllocation from "@components/PageEcoSystem/FrankencoinAllocation";
+import CollateralAndPositionsOverview from "@components/PageEcoSystem/CollateralAndPositionsOverview";
 
 export default function Positions() {
+	const posCount = useSelector((state: RootState) => state.positions.openPositions.length);
+	const activeChallengeCount = useSelector((state: RootState) => state.challenges.list.list.filter((c) => c.status === "Active").length);
+
 	useEffect(() => {
 		store.dispatch(fetchPositionsList());
 		store.dispatch(fetchMarketChart());
@@ -21,43 +31,108 @@ export default function Positions() {
 				<title>Frankencoin - Monitoring</title>
 			</Head>
 
-			<AppTitle title="Market">
+			<AppTitle title="Monitoring">
 				<div className="text-text-secondary">
-					Price and volume data as reported by{" "}
-					<AppLink className="" label="Coingecko" href={"https://www.coingecko.com/en/coins/frankencoin"} external={true} />
+					Monitor the health of the Frankencoin protocol. Spot undercollateralized positions, earn a 2% reward by challenging
+					them, and buy collateral from active auctions at a discount. Track reserves, supply distribution, and system
+					collateralization over time.
 				</div>
 			</AppTitle>
-			<div className="md:mt-8">
-				<MarketChart />
-			</div>
 
-			<AppTitle title="Positions">
-				<div className="text-text-secondary">
-					Look out for undercollateralized positions and earn a 2% reward for successfully challenging them.
-				</div>
-			</AppTitle>
-			<div className="md:mt-8">
-				<MonitoringTable />
-			</div>
+			<PageTabInput
+				tabs={[
+					{
+						label: "Positions & Auctions",
+						badge: activeChallengeCount,
+						content: (
+							<>
+								<div className="mt-8">
+									<AppHeroSteps
+										steps={[
+											{
+												title: "Earn rewards by protecting the protocol",
+												description:
+													"Find undercollateralized positions below, challenge them by putting up your own collateral, and earn 2% of the auction proceeds if the challenge succeeds.",
+												icon: <FontAwesomeIcon icon={faTrophy} />,
+											},
+											{
+												title: "Acquire collateral from auctions",
+												description:
+													"When positions are challenged, their collateral goes to auction. Pay ZCHF to receive the collateral tokens. In Phase 1 at a fixed price, in Phase 2 at a declining price.",
+												icon: <FontAwesomeIcon icon={faGavel} />,
+											},
+										]}
+									/>
+								</div>
 
-			<AppTitle title="Auctions">
-				<div className="text-text-secondary">
-					Buy collateral of challenged or expired positions in a Dutch auction. See the{" "}
-					<AppLink label="challenges & bids overview" href="/monitoring/challenges" external={false} className="" /> for a
-					complete track record.
-				</div>
-			</AppTitle>
-			<div className="md:mt-8">
-				<ChallengesTable />
-			</div>
-			<AppTitle title="Further Tools">
-				<div className="text-text-secondary">
-					Have a look at the{" "}
-					<AppLink label="collaterals overview" href="/monitoring/collateral" external={false} className="" />, a{" "}
-					<AppLink label="general system metrics" href="/monitoring/ecosystem" external={false} className="" />, or the{" "}
-					<AppLink className="" label="transaction logbook" href={"/monitoring/logs?kind=Frankencoin"} external={false} />.
-				</div>
-			</AppTitle>
+								<AppTitle title="Auctions" badge={String(activeChallengeCount)}>
+									<div className="text-text-secondary">
+										Buy collateral of challenged or expired positions in a Dutch auction. See the{" "}
+										<AppLink
+											label="challenges & bids overview"
+											href="/monitoring/challenges"
+											external={false}
+											className=""
+										/>{" "}
+										for a complete track record.
+									</div>
+								</AppTitle>
+
+								<ChallengesTable />
+
+								<AppTitle title="Positions" badge={String(posCount)}>
+									<div className="text-text-secondary">
+										Look out for undercollateralized positions and earn a 2% reward for successfully challenging them.
+									</div>
+								</AppTitle>
+
+								<MonitoringTable />
+							</>
+						),
+					},
+					{
+						label: "System Health",
+						content: (
+							<>
+								<AppTitle title="Market">
+									<div className="text-text-secondary">
+										Price and volume data as reported by{" "}
+										<AppLink
+											className=""
+											label="Coingecko"
+											href={"https://www.coingecko.com/en/coins/frankencoin"}
+											external={true}
+										/>
+									</div>
+								</AppTitle>
+								<div className="md:mt-8">
+									<MarketChart />
+								</div>
+
+								<AppTitle title={`Frankencoin Holders`}>
+									<div className="text-text-secondary">
+										This section provides an overview of how the total ZCHF supply is distributed among different
+										holders. The circulating supply reflects tokens held in uncategorized wallets, while other portions
+										are allocated to protocol reserves, centralized & decentralized exchanges, and external integrations
+										such as Morpho.
+									</div>
+								</AppTitle>
+								<div className="my-[2rem]">
+									<FrankencoinAllocation />
+								</div>
+							</>
+						),
+					},
+					{
+						label: "Collateral Overview",
+						content: (
+							<div className={`pt-6`}>
+								<CollateralAndPositionsOverview />
+							</div>
+						),
+					},
+				]}
+			/>
 		</>
 	);
 }

--- a/pages/monitoring/index.tsx
+++ b/pages/monitoring/index.tsx
@@ -23,6 +23,7 @@ import ReserveAllocation from "@components/PageEcoSystem/ReserveAllocation";
 export default function Positions() {
 	const posCount = useSelector((state: RootState) => state.positions.openPositions.length);
 	const activeChallengeCount = useSelector((state: RootState) => state.challenges.list.list.filter((c) => c.status === "Active").length);
+	const collateralCount = useSelector((state: RootState) => state.positions.openPositionsByCollateral.length) + 1; // +1 for VCHF bridge
 
 	useEffect(() => {
 		store.dispatch(fetchPositionsList());
@@ -112,6 +113,12 @@ export default function Positions() {
 									<HealthRatio />
 								</div>
 
+								<AppTitle title={`Market Data`}>
+									<div className="text-text-secondary">
+										This section shows the recent exchange rate and 24h trading volume of ZCHF on the open market. Data sourced from CoinGecko.
+									</div>
+								</AppTitle>
+
 								<div className="md:mt-8">
 									<MarketChart />
 								</div>
@@ -172,7 +179,7 @@ export default function Positions() {
 						label: "Collateral Overview",
 						content: (
 							<>
-								<AppTitle title={`Accepted Collateral Assets`}>
+								<AppTitle title={`Accepted Collateral Assets`} badge={String(collateralCount)}>
 									<div className="text-text-secondary">
 										An overview of all collateral types currently accepted by the Frankencoin protocol.
 									</div>

--- a/pages/monitoring/index.tsx
+++ b/pages/monitoring/index.tsx
@@ -12,9 +12,9 @@ import { useSelector } from "react-redux";
 import PageTabInput from "@components/Input/PageTabInput";
 import AppHeroSteps from "@components/AppHeroSteps";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faAward, faGavel, faMoneyBill, faTrophy } from "@fortawesome/free-solid-svg-icons";
+import { faGavel, faTrophy } from "@fortawesome/free-solid-svg-icons";
 import FrankencoinAllocation from "@components/PageEcoSystem/FrankencoinAllocation";
-import CollateralAndPositionsOverview from "@components/PageEcoSystem/CollateralAndPositionsOverview";
+import CollateralOverviewTable from "@components/PageMonitoring/CollateralOverviewTable";
 
 export default function Positions() {
 	const posCount = useSelector((state: RootState) => state.positions.openPositions.length);
@@ -126,8 +126,8 @@ export default function Positions() {
 					{
 						label: "Collateral Overview",
 						content: (
-							<div className={`pt-6`}>
-								<CollateralAndPositionsOverview />
+							<div className="mt-8">
+								<CollateralOverviewTable />
 							</div>
 						),
 					},

--- a/pages/monitoring/index.tsx
+++ b/pages/monitoring/index.tsx
@@ -15,6 +15,10 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGavel, faTrophy } from "@fortawesome/free-solid-svg-icons";
 import FrankencoinAllocation from "@components/PageEcoSystem/FrankencoinAllocation";
 import CollateralOverviewTable from "@components/PageMonitoring/CollateralOverviewTable";
+import HealthRatio from "@components/PageEcoSystem/HealthRatio";
+import DebtAllocation from "@components/PageEcoSystem/DebtAllocation";
+import MintOutstanding from "@components/PageEcoSystem/MintOutstanding";
+import ReserveAllocation from "@components/PageEcoSystem/ReserveAllocation";
 
 export default function Positions() {
 	const posCount = useSelector((state: RootState) => state.positions.openPositions.length);
@@ -94,17 +98,20 @@ export default function Positions() {
 						label: "System Health",
 						content: (
 							<>
-								<AppTitle title="Market">
+								<AppTitle title={`System Health`}>
 									<div className="text-text-secondary">
-										Price and volume data as reported by{" "}
-										<AppLink
-											className=""
-											label="Coingecko"
-											href={"https://www.coingecko.com/en/coins/frankencoin"}
-											external={true}
-										/>
+										This chart shows how well the Frankencoins in free circulation are backed by collateral assets. All
+										Frankencoins that are not in the reserve pool are considered in free circulation. To the extent this
+										value falls below 100%, the fundamental value of falls below below the peg. As long as the value is
+										above 100%, all Frankencoins in free circulation are backed by collateral. The recording of historic
+										watermarks started in September 2025.
 									</div>
 								</AppTitle>
+
+								<div className="md:mt-8">
+									<HealthRatio />
+								</div>
+
 								<div className="md:mt-8">
 									<MarketChart />
 								</div>
@@ -119,6 +126,44 @@ export default function Positions() {
 								</AppTitle>
 								<div className="my-[2rem]">
 									<FrankencoinAllocation />
+								</div>
+
+								<AppTitle title={`Current Debt`}>
+									<div className="text-text-secondary">
+										This section provides an overview of the current debt of all collateral positions. The current debt
+										is calculated as the total minted amount of a position minus the reserve contribution, which can be
+										reclaimed by repaying the outstanding debt.
+									</div>
+								</AppTitle>
+
+								<div className="my-[2rem]">
+									<DebtAllocation />
+								</div>
+
+								<AppTitle title={`Expiration Trajectory`}>
+									<div className="text-text-secondary">
+										A chart showing by when the Frankencoins currently in circulation need to be repaid by their
+										minters.
+									</div>
+								</AppTitle>
+
+								<div className="my-[2rem]">
+									<MintOutstanding />
+								</div>
+
+								<AppTitle title={`Reserves`}>
+									<div className="text-text-secondary">
+										In case a position has to be liquidated because it is not well-collateralized any more, the losses
+										are covered by three layers of reserves in the following order: first the minter reserve of the
+										liquidated position is used. If that does not suffice, equity capital is burned. If that does not
+										suffice either, the reserves of all other positions are proportionally reduced. After all the
+										reserves have been burned, a furher loss would reduce the fundamental value of the Frankencoin below
+										the peg.
+									</div>
+								</AppTitle>
+
+								<div className="my-[2rem]">
+									<ReserveAllocation />
 								</div>
 							</>
 						),

--- a/pages/mypositions/[address]/index.tsx
+++ b/pages/mypositions/[address]/index.tsx
@@ -3,7 +3,17 @@ import { useEffect, useState } from "react";
 import { formatUnits, maxUint256, erc20Abi, Address, parseEther, parseUnits } from "viem";
 import Head from "next/head";
 import TokenInput from "@components/Input/TokenInput";
-import { abs, bigIntMax, bigIntMin, ContractUrl, formatBigInt, formatCurrency, formatDuration, normalizeAddress, shortenAddress } from "@utils";
+import {
+	abs,
+	bigIntMax,
+	bigIntMin,
+	ContractUrl,
+	formatBigInt,
+	formatCurrency,
+	formatDuration,
+	normalizeAddress,
+	shortenAddress,
+} from "@utils";
 import Button from "@components/Button";
 import { useAccount, useBlockNumber, useChainId } from "wagmi";
 import { readContract, waitForTransactionReceipt, writeContract } from "wagmi/actions";
@@ -389,17 +399,25 @@ export default function PositionAdjust() {
 				<title>Frankencoin - Manage Position</title>
 			</Head>
 
-			<AppTitle title={`Manage Position `}>
-				<div className="text-text-secondary">
-					Based on contract{" "}
-					<AppLink
-						label={shortenAddress(position.position) + "."}
-						href={ContractUrl(position.position)}
-						external={true}
-						className="pr-1"
-					/>
-				</div>
-			</AppTitle>
+			<AppTitle
+				title={`${position.collateralName} (${position.collateralSymbol})`}
+				subtitle={`Manage your position.`}
+				badges={[
+					position.closed
+						? { label: "Closed", className: "bg-red-500/20 text-red-400" }
+						: isCooldown
+						? { label: "Cooldown", className: "bg-amber-500/20 text-amber-400" }
+						: { label: "Active", className: "bg-green-500/20 text-green-400" },
+					{ label: `V${position.version}`, className: "bg-blue-500/20 text-blue-400" },
+					...(position.isClone ? [{ label: "Clone", className: "bg-purple-500/20 text-purple-400" }] : []),
+				]}
+				actions={
+					<div className="flex flex-wrap gap-4 text-sm">
+						<AppLink label="Contract" href={ContractUrl(position.position)} external={true} />
+						<AppLink label="Details" href={`/monitoring/${position.position}`} external={false} />
+					</div>
+				}
+			/>
 
 			<div className="md:mt-8">
 				<section className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/pages/mypositions/[address]/index.tsx
+++ b/pages/mypositions/[address]/index.tsx
@@ -413,8 +413,8 @@ export default function PositionAdjust() {
 				]}
 				actions={
 					<div className="flex flex-wrap gap-4 text-sm">
-						<AppLink label="Contract" href={ContractUrl(position.position)} external={true} />
 						<AppLink label="Details" href={`/monitoring/${position.position}`} external={false} />
+						<AppLink label="Contract" href={ContractUrl(position.position)} external={true} />
 					</div>
 				}
 			/>

--- a/utils/collateralCategories.ts
+++ b/utils/collateralCategories.ts
@@ -38,6 +38,7 @@ const COLLATERAL_CATEGORIES: Record<string, CollateralCategory[]> = {
 	"0x2e880962a9609aa3eab4def919fe9e917e99073b": ["Tokenized Securities"], // BOSS
 	"0x553c7f9c780316fc1d34b8e14ac2465ab22a090b": ["Tokenized Securities"], // REALU
 	"0x343324f53cbeee3ee6d171f2a20f005964c98047": ["Tokenized Securities"], // LENDS
+	"0xfedc5f4a6c38211c1338aa411018dfaf26612c08": ["Tokenized Securities"], // SPYon
 };
 
 export function getCategoriesForCollateral(address: string): CollateralCategory[] {

--- a/utils/constant.ts
+++ b/utils/constant.ts
@@ -54,23 +54,23 @@ export const colors = [
 	"#69d2e7",
 ];
 
-// Discussions
+// Discussions — keys are lowercase addresses (use normalizeAddress for lookup)
 export const DISCUSSIONS: {
 	[key: string]: string;
 } = {
 	default: "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions", // default url
-	"0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/17", // WBTC
-	"0x8c1BEd5b9a0928467c9B1341Da1D7BD5e10b6549": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/15", // LsETH
-	"0x6810e776880C02933D47DB1b9fc05908e5386b96": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/79", // GNO
-	"0x2E880962A9609aA3eab4DEF919FE9E917E99073B": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/13", // BOSS
-	"0x343324F53CBEEE3Ee6d171f2a20F005964C98047": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/80", // LENDS
-	"0x23346B04a7f55b8760E5860AA5A77383D63491cD": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/94", // ysyBOLD
-	"0x45804880De22913dAFE09f4980848ECE6EcbAf78": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/82", // PAXG
-	"0x553C7f9C780316FC1D34b8e14ac2465Ab22a090B": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/14", // REALU
-	"0x68749665FF8D2d112Fa859AA293F07A622782F38": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/83", // XAUt
-    "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "https://coinmarketcap.com/currencies/lido-finance-wsteth/", // wstETH
-	"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "https://coinmarketcap.com/currencies/weth/", // WETH
-	"0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/17", // cbBTC
-    "0xD533a949740bb3306d119CC777fa900bA034cd52": "https://coinmarketcap.com/currencies/curve-dao-token/", // crv
-	"0xFeDC5f4a6c38211c1338aa411018DFAf26612c08": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/84", // SPYon
+	"0x2260fac5e5542a773aa44fbcfedf7c193bc2c599": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/17", // WBTC
+	"0x8c1bed5b9a0928467c9b1341da1d7bd5e10b6549": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/15", // LsETH
+	"0x6810e776880c02933d47db1b9fc05908e5386b96": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/79", // GNO
+	"0x2e880962a9609aa3eab4def919fe9e917e99073b": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/13", // BOSS
+	"0x343324f53cbeee3ee6d171f2a20f005964c98047": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/80", // LENDS
+	"0x23346b04a7f55b8760e5860aa5a77383d63491cd": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/94", // ysyBOLD
+	"0x45804880de22913dafe09f4980848ece6ecbaf78": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/82", // PAXG
+	"0x553c7f9c780316fc1d34b8e14ac2465ab22a090b": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/14", // REALU
+	"0x68749665ff8d2d112fa859aa293f07a622782f38": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/83", // XAUt
+	"0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0": "https://coinmarketcap.com/currencies/lido-finance-wsteth/", // wstETH
+	"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "https://coinmarketcap.com/currencies/weth/", // WETH
+	"0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/17", // cbBTC
+	"0xd533a949740bb3306d119cc777fa900ba034cd52": "https://coinmarketcap.com/currencies/curve-dao-token/", // crv
+	"0xfedc5f4a6c38211c1338aa411018dfaf26612c08": "https://github.com/Frankencoin-ZCHF/Frankencoin/discussions/84", // SPYon
 };


### PR DESCRIPTION
## Summary

- **TableHeadSearchable**: extended with state categories and badge support for richer filtering UX
- **CollateralOverviewTable**: new component integrating VCHF stablecoin bridge as a collateral row with market data and CoinGecko attribution
- **Monitoring page overhaul**: expanded System Health tab with health ratio, debt, expiration, and reserve sections; added Position History section title; new minting history, auction cards, and stat layout on position detail page
- **Health Ratio card**: redesigned with current value, progress bar, stats, and area chart; simplified date format and adjusted green color tone
- **Mint Outstanding**: redesigned with area chart and paginated maturity list
- **Ecosystem charts**: aggregate items beyond 10 into "Others" in debt and reserve charts
- **Mint page**: linked inputs toggle to sync collateral, mint, and liquidation price; show nominal LTV on liquidation slider; clamp liquidation price to reference when link is active; top margin fix on alternative terms section
- **AppTitle**: added badges, subtitle, and actions props; updated mint and mypositions headers to use new badges
- **Input components**: reorder buttons to Min→Reset→Max, add limitUnit/limitCurrency props
- **Borrow page**: replace effective LTV with nominal LTV (liqPrice / marketPrice)
- **Governance**: warn about uint40 overflow deadline in leadrate contract
- **Misc**: normalize DISCUSSIONS keys to lowercase, layout top padding adjustments, version bump to 0.2.20

## Test plan

- [x] Verify collateral overview table renders correctly with VCHF bridge row
- [x] Test searchable table filtering with state categories and badges
- [x] Confirm health ratio card displays correct values, progress bar, and chart
- [x] Test linked inputs on mint page (collateral ↔ mint ↔ liquidation price sync)
- [x] Verify nominal LTV calculation on borrow and mint pages
- [x] Check ecosystem charts collapse beyond-10 items into "Others"
- [x] Review monitoring position detail page layout (minting history, auction cards)
- [x] Confirm uint40 overflow warning appears in governance leadrate section

🤖 Generated with [Claude Code](https://claude.com/claude-code)