### PR TITLE
fix(ui): replace AppBox with div for mobile row wrappers

### DIFF
--- a/components/PageBorrow/BorrowMorphoRow.tsx
+++ b/components/PageBorrow/BorrowMorphoRow.tsx
@@ -2,7 +2,6 @@ import TableRow from "../Table/TableRow";
 import { formatCurrency } from "../../utils/format";
 import DisplayCollateralBorrowTable from "./DisplayCollateralBorrowTable";
 import Button from "@components/Button";
-import AppBox from "@components/AppBox";
 import { Market } from "../../redux/slices/morpho.types";
 import { MorphoMarketUrl } from "@utils";
 import { formatUnits } from "viem";
@@ -39,7 +38,7 @@ export default function BorrowMorphoRow({ headers, tab, market }: Props) {
 			}
 		>
 			<div className="flex flex-col max-md:mb-5">
-				<AppBox className="md:hidden">
+				<div className="md:hidden">
 					<DisplayCollateralBorrowTable
 						symbol={market.collateralAsset.symbol}
 						name={market.collateralAsset.name}
@@ -47,7 +46,7 @@ export default function BorrowMorphoRow({ headers, tab, market }: Props) {
 						price={0}
 						hideMyWallet
 					/>
-				</AppBox>
+				</div>
 				<div className="max-md:hidden">
 					<DisplayCollateralBorrowTable
 						symbol={market.collateralAsset.symbol}

--- a/components/PageBorrow/BorrowRow.tsx
+++ b/components/PageBorrow/BorrowRow.tsx
@@ -5,7 +5,6 @@ import { useRouter as useNavigation } from "next/navigation";
 import { formatCurrency, FormatType, normalizeAddress } from "../../utils/format";
 import { PositionQueryV2 } from "@frankencoin/api";
 import DisplayCollateralBorrowTable from "./DisplayCollateralBorrowTable";
-import AppBox from "@components/AppBox";
 import { formatUnits } from "viem";
 import { SwapVCHFStatsReturn } from "@hooks";
 import Button from "@components/Button";
@@ -64,7 +63,7 @@ export default function BorrowRow({ headers, tab, position, vchfBridge, hideMyWa
 			}
 		>
 			<div className="flex flex-col max-md:mb-5">
-				<AppBox className="md:hidden">
+				<div className="md:hidden">
 					<DisplayCollateralBorrowTable
 						symbol={position.collateralSymbol}
 						// symbolTiny={`v${position.version}`}
@@ -74,7 +73,7 @@ export default function BorrowRow({ headers, tab, position, vchfBridge, hideMyWa
 						hideMyWallet={hideMyWallet}
 						balance={collateralBalance}
 					/>
-				</AppBox>
+				</div>
 				<div className="max-md:hidden">
 					<DisplayCollateralBorrowTable
 						symbol={position.collateralSymbol}

--- a/components/PageChallenges/ChallengesRow.tsx
+++ b/components/PageChallenges/ChallengesRow.tsx
@@ -8,7 +8,6 @@ import { formatCurrency, normalizeAddress } from "../../utils/format";
 import { useRouter as useNavigation } from "next/navigation";
 import Button from "@components/Button";
 import { useContractUrl } from "@hooks";
-import AppBox from "@components/AppBox";
 
 interface Props {
 	headers: string[];
@@ -96,14 +95,14 @@ export default function ChallengesRow({ headers, tab, challenge }: Props) {
 				</div>
 
 				{/* mobile view */}
-				<AppBox className="md:hidden flex flex-row items-center">
+				<div className="md:hidden flex flex-row items-center">
 					<div className="mr-4 cursor-pointer" onClick={openExplorer}>
 						<TokenLogo currency={position.collateralSymbol} />
 					</div>
 					<div className={`col-span-2 text-md text-text-primary font-semibold`}>{`${formatCurrency(challengeRemainingSize)} ${
 						position.collateralSymbol
 					}`}</div>
-				</AppBox>
+				</div>
 			</div>
 
 			{/* Current Price */}

--- a/components/PageGovernance/GovernancePositionsRow.tsx
+++ b/components/PageGovernance/GovernancePositionsRow.tsx
@@ -4,7 +4,6 @@ import { PositionQuery, PriceQueryObjectArray } from "@frankencoin/api";
 import { formatCurrency, FormatType, normalizeAddress, shortenAddress } from "../../utils/format";
 import GovernancePositionsAction from "./GovernancePositionsAction";
 import DisplayCollateralBorrowTable from "@components/PageBorrow/DisplayCollateralBorrowTable";
-import AppBox from "@components/AppBox";
 import AppLink from "@components/AppLink";
 import { ContractUrl } from "@utils";
 
@@ -51,7 +50,7 @@ export default function GovernancePositionsRow({ headers, subHeaders, tab, posit
 				</div>
 
 				{/* mobile view */}
-				<AppBox className="md:hidden flex flex-row items-center">
+				<div className="md:hidden flex flex-row items-center">
 					<DisplayCollateralBorrowTable
 						symbol={position.collateralSymbol}
 						symbolTiny={`v${position.version}`}
@@ -60,7 +59,7 @@ export default function GovernancePositionsRow({ headers, subHeaders, tab, posit
 						price={price.price.usd ?? 0}
 						balance={balance}
 					/>
-				</AppBox>
+				</div>
 			</div>
 
 			<div className="flex flex-col">

--- a/components/PageMypositions/MyPositionsBidsRow.tsx
+++ b/components/PageMypositions/MyPositionsBidsRow.tsx
@@ -9,7 +9,6 @@ import { useContractUrl } from "@hooks";
 import { useRouter as useNavigation } from "next/navigation";
 import Button from "@components/Button";
 import { useAccount } from "wagmi";
-import AppBox from "@components/AppBox";
 import { TxUrl } from "@utils";
 import ButtonSecondary from "@components/ButtonSecondary";
 
@@ -82,14 +81,14 @@ export default function MyPositionsBidsRow({ headers, tab, bid }: Props) {
 				</div>
 
 				{/* mobile view */}
-				<AppBox className="md:hidden flex flex-row items-center">
+				<div className="md:hidden flex flex-row items-center">
 					<div className="mr-4 cursor-pointer" onClick={openExplorer}>
 						<TokenLogo currency={position.collateralSymbol} />
 					</div>
 					<div className={`col-span-2 text-md`}>{`${formatCurrency(formatUnits(bid.filledSize, position.collateralDecimals))} ${
 						position.collateralSymbol
 					}`}</div>
-				</AppBox>
+				</div>
 			</div>
 
 			{/* Price */}

--- a/components/PageMypositions/MyPositionsChallengesRow.tsx
+++ b/components/PageMypositions/MyPositionsChallengesRow.tsx
@@ -7,7 +7,6 @@ import TokenLogo from "@components/TokenLogo";
 import { formatCurrency, normalizeAddress } from "../../utils/format";
 import { useContractUrl } from "@hooks";
 import MyPositionsChallengesCancel from "./MyPositionsChallengesCancel";
-import AppBox from "@components/AppBox";
 
 interface Props {
 	headers: string[];
@@ -83,12 +82,12 @@ export default function MyPositionsChallengesRow({ headers, tab, challenge }: Pr
 				</div>
 
 				{/* mobile view */}
-				<AppBox className="md:hidden flex flex-row items-center">
+				<div className="md:hidden flex flex-row items-center">
 					<div className="mr-4 cursor-pointer" onClick={openExplorer}>
 						<TokenLogo currency={position.collateralSymbol} />
 					</div>
 					<div className={`col-span-2 text-md`}>{`${formatCurrency(challengeSize)} ${position.collateralSymbol}`}</div>
-				</AppBox>
+				</div>
 			</div>
 
 			{/* Averted Ratio */}

--- a/components/PageMypositions/MypositionsRow.tsx
+++ b/components/PageMypositions/MypositionsRow.tsx
@@ -7,7 +7,6 @@ import { formatCurrency, normalizeAddress } from "../../utils/format";
 import MyPositionsDisplayCollateral from "./MyPositionsDisplayCollateral";
 import { useRouter as useNavigate } from "next/navigation";
 import Button from "@components/Button";
-import AppBox from "@components/AppBox";
 
 interface Props {
 	headers: string[];
@@ -153,14 +152,14 @@ export default function MypositionsRow({ headers, tab, subHeaders, position }: P
 					<MyPositionsDisplayCollateral position={position} collateralPrice={collTokenPrice} zchfPrice={zchfPrice} />
 				</div>
 				{/* mobile view */}
-				<AppBox className="md:hidden">
+				<div className="md:hidden">
 					<MyPositionsDisplayCollateral
 						className={"justify-items-center items-center"}
 						position={position}
 						collateralPrice={collTokenPrice}
 						zchfPrice={zchfPrice}
 					/>
-				</AppBox>
+				</div>
 			</div>
 
 			{/* Liquidation */}

--- a/components/Table/TableHeadSearchable.tsx
+++ b/components/Table/TableHeadSearchable.tsx
@@ -115,6 +115,9 @@ export default function TableHeadSearchable({
 					/>
 				</div>
 
+				{/* Divider between search and controls — mobile only */}
+				<div className="md:hidden border-t border-gray-100 dark:border-gray-700 -mx-7 xl:-mx-11" />
+
 				{/* Right controls */}
 				<div className="flex items-center justify-end gap-5">
 					{/* In my wallet toggle */}


### PR DESCRIPTION
## Summary

- Replaces `AppBox` wrapper with a plain `div` in the mobile view of 7 row components (`BorrowRow`, `BorrowMorphoRow`, `ChallengesRow`, `GovernancePositionsRow`, `MyPositionsBidsRow`, `MyPositionsChallengesRow`, `MypositionsRow`)
- Adds a mobile-only horizontal divider between the search input and table controls in `TableHeadSearchable`

## Test plan

- [ ] Verify mobile layout renders correctly for Borrow, Challenges, Governance, and My Positions rows
- [ ] Verify the search/controls divider appears on mobile and is hidden on desktop (`md:hidden`)
- [ ] Confirm no visual regression on desktop views

🤖 Generated with [Claude Code](https://claude.com/claude-code)