### PR TITLE
fix: correct CHFAU decimal handling and per-block swap stats refresh

### DIFF
--- a/hooks/useSwapCHFAUStats.ts
+++ b/hooks/useSwapCHFAUStats.ts
@@ -1,4 +1,5 @@
-import { useConnection, useReadContracts } from "wagmi";
+import { useBlockNumber, useConnection, useReadContracts } from "wagmi";
+import { useEffect } from "react";
 import { decodeBigIntCall, normalizeAddress } from "@utils";
 import { Address, erc20Abi, formatUnits, parseUnits, zeroAddress } from "viem";
 import { ADDRESS, StablecoinBridgeV2ABI } from "@frankencoin/zchf";
@@ -20,7 +21,8 @@ export const useSwapCHFAUStats = (): SwapVCHFStatsReturn => {
 	const other = ADDRESS[chainId].chfauToken;
 	const bridge = ADDRESS[chainId].stablecoinBridgeCHFAU;
 
-	const { data, isError, isLoading } = useReadContracts({
+	const { data: blockNumber } = useBlockNumber({ watch: true });
+	const { data, refetch, isError, isLoading } = useReadContracts({
 		contracts: [
 			// CHFAU token calls
 			{ chainId, address: other, abi: erc20Abi, functionName: "balanceOf", args: [account] },
@@ -37,6 +39,10 @@ export const useSwapCHFAUStats = (): SwapVCHFStatsReturn => {
 			{ chainId, address: bridge, abi: StablecoinBridgeV2ABI, functionName: "minted" },
 		],
 	});
+
+	useEffect(() => {
+		refetch();
+	}, [blockNumber]);
 
 	const otherUserBal: bigint = data ? decodeBigIntCall(data[0]) : 0n;
 	const otherSymbol: string = data ? String(data[1].result) : "";
@@ -165,6 +171,7 @@ export const useSwapCHFAUStats = (): SwapVCHFStatsReturn => {
 		zchfSymbol,
 		zchfUserAllowance,
 
+		bridgeMinted,
 		bridgeLimit,
 		bridgeHorizon,
 		asBorrowPosition,

--- a/hooks/useSwapVCHFStats.ts
+++ b/hooks/useSwapVCHFStats.ts
@@ -1,4 +1,5 @@
-import { useConnection, useReadContracts } from "wagmi";
+import { useBlockNumber, useConnection, useReadContracts } from "wagmi";
+import { useEffect } from "react";
 import { decodeBigIntCall, normalizeAddress } from "@utils";
 import { Address, erc20Abi, formatUnits, parseUnits, zeroAddress } from "viem";
 import { ADDRESS, StablecoinBridgeV1ABI, StablecoinBridgeV2ABI } from "@frankencoin/zchf";
@@ -56,6 +57,7 @@ export type SwapVCHFStatsReturn = {
 	zchfUserBal: bigint;
 	zchfSymbol: string;
 	zchfUserAllowance: bigint;
+	bridgeMinted: bigint;
 	bridgeLimit: bigint;
 	bridgeHorizon: bigint;
 	// rich objects
@@ -75,7 +77,8 @@ export const useSwapVCHFStats = (): SwapVCHFStatsReturn => {
 	const other = ADDRESS[chainId].vchfToken;
 	const bridge = ADDRESS[chainId].stablecoinBridgeVCHF;
 
-	const { data, isError, isLoading } = useReadContracts({
+	const { data: blockNumber } = useBlockNumber({ watch: true });
+	const { data, refetch, isError, isLoading } = useReadContracts({
 		contracts: [
 			// VCHF token calls
 			{ chainId, address: other, abi: erc20Abi, functionName: "balanceOf", args: [account] },
@@ -91,6 +94,10 @@ export const useSwapVCHFStats = (): SwapVCHFStatsReturn => {
 			{ chainId, address: bridge, abi: StablecoinBridgeV1ABI, functionName: "horizon" },
 		],
 	});
+
+	useEffect(() => {
+		refetch();
+	}, [blockNumber]);
 
 	const otherUserBal: bigint = data ? decodeBigIntCall(data[0]) : 0n;
 	const otherSymbol: string = data ? String(data[1].result) : "";
@@ -218,6 +225,7 @@ export const useSwapVCHFStats = (): SwapVCHFStatsReturn => {
 		zchfSymbol,
 		zchfUserAllowance,
 
+		bridgeMinted: otherBridgeBal,
 		bridgeLimit,
 		bridgeHorizon,
 		asBorrowPosition,

--- a/pages/swap.tsx
+++ b/pages/swap.tsx
@@ -30,7 +30,7 @@ export default function Swap() {
 	const router = useRouter();
 	const vchfStats = useSwapVCHFStats();
 	const chfauStats = useSwapCHFAUStats();
-	const swapStats = (router.query.token as string)?.toUpperCase() === "CHFAU" ? chfauStats : vchfStats;
+	const swapStats = (router.query.token as string)?.toUpperCase() === "VCHF" ? vchfStats : chfauStats;
 
 	const { chain, chainId, otherAddress: other, bridgeAddress: bridge, frankencoinAddress, bridgeAbi, otherDecimals } = swapStats;
 	const bridgeUrl = useContractUrl(bridge);
@@ -42,8 +42,8 @@ export default function Swap() {
 		decimalDiff > 0
 			? amount * BigInt(10) ** BigInt(decimalDiff)
 			: decimalDiff < 0
-				? amount / BigInt(10) ** BigInt(-decimalDiff)
-				: amount;
+			? amount / BigInt(10) ** BigInt(-decimalDiff)
+			: amount;
 
 	// Reset state when switching bridges; init direction to burn if already expired
 	useEffect(() => {
@@ -59,10 +59,10 @@ export default function Swap() {
 
 	const activeMinter = isMinter > 0 && isMinter * 1000n <= Date.now();
 	const fromBalance = direction ? swapStats.otherUserBal : swapStats.zchfUserBal;
-	const toBalance = !direction ? swapStats.otherUserBal : swapStats.zchfUserBal;
 	const fromSymbol = direction ? swapStats.otherSymbol : "ZCHF";
 	const toSymbol = !direction ? swapStats.otherSymbol : "ZCHF";
-	const swapLimit = direction ? swapStats.bridgeLimit - swapStats.otherBridgeBal : swapStats.otherBridgeBal;
+	const swapLimit = direction ? swapStats.bridgeLimit - swapStats.bridgeMinted : swapStats.bridgeMinted; // (18 digits)
+	const swapLimitCorrected = (swapLimit * 10n ** BigInt(fromDecimals)) / 10n ** 18n;
 
 	useEffect(() => {
 		const fetcher = async () => {
@@ -101,14 +101,14 @@ export default function Swap() {
 	}, [activeMinter, swapStats, direction]);
 
 	useEffect(() => {
-		if (amount > fromBalance) {
-			setError(`Not enough ${fromSymbol} in your wallet.`);
-		} else if (amount > swapLimit) {
+		if (amount > swapLimitCorrected) {
 			setError(`Not enough ${toSymbol} available to swap.`);
+		} else if (amount > fromBalance) {
+			setError(`Not enough ${fromSymbol} in your wallet.`);
 		} else {
 			setError("");
 		}
-	}, [amount, direction, fromBalance, fromSymbol, swapLimit, toSymbol]);
+	}, [amount, direction, fromBalance, fromSymbol, swapLimitCorrected, toSymbol]);
 
 	const handleApprove = async () => {
 		try {
@@ -233,6 +233,7 @@ export default function Swap() {
 	};
 
 	const onChangeDirection = () => {
+		setAmount(toAmount);
 		setDirection(!direction);
 	};
 
@@ -261,12 +262,12 @@ export default function Swap() {
 
 						<div className="mt-8">
 							<TokenInput
-								max={fromBalance < swapLimit ? fromBalance : swapLimit}
+								max={fromBalance < swapLimitCorrected ? fromBalance : swapLimitCorrected}
 								reset={0n}
 								digit={fromDecimals}
-								limitDigit={fromDecimals}
 								symbol={fromSymbol}
 								limit={fromBalance}
+								limitDigit={fromDecimals}
 								limitLabel="Balance"
 								placeholder={"Swap Amount"}
 								onChange={onChangeAmount}
@@ -284,7 +285,7 @@ export default function Swap() {
 						<TokenInput
 							symbol={toSymbol}
 							digit={toDecimals}
-							limitDigit={toDecimals}
+							limitDigit={18}
 							limit={swapLimit}
 							limitLabel="Available"
 							value={toAmount.toString()}


### PR DESCRIPTION
## Summary
- Fix swap limit calculation to use `bridgeMinted` instead of `otherBridgeBal`, ensuring correct 18-decimal handling when CHFAU has 6 decimals
- Add `swapLimitCorrected` to properly scale the limit to the input token's decimals before comparison
- Fix default token selection: CHFAU is now the default when no `?token=` query param is set
- Add per-block refresh to both `useSwapCHFAUStats` and `useSwapVCHFStats` via `useBlockNumber({ watch: true })` so balances and limits update automatically after a swap or approve — no page reload required
- Preserve the converted amount when toggling swap direction

## Test plan
- [x] Swap CHFAU → ZCHF: verify available limit and balance display correctly (accounting for 6 vs 18 decimals)
- [x] Swap ZCHF → CHFAU: verify limit reflects `bridgeMinted` correctly
- [x] Approve + swap: confirm balances update on the next block without reloading
- [x] Toggle direction: confirm amount carries over as the converted value
- [x] Navigate to `/swap` (no query param): confirm CHFAU is selected by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)