### PR TITLE
feat: CCIP Admin Proposals governance section with actions

### DIFF
--- a/components/AppButton.tsx
+++ b/components/AppButton.tsx
@@ -26,7 +26,7 @@ export default function AppButton({
 	loading,
 	icon,
 	className,
-	size,
+	size = "medium",
 	disabled,
 	width,
 	onClick = () => {},
@@ -37,7 +37,7 @@ export default function AppButton({
 	umamiEvent,
 }: Props) {
 	const busy = isLoading || loading;
-	const sizeClass = size === "small" ? "px-2 py-1 md:px-3 md:py-1 text-sm" : size === "medium" ? "px-3 py-2 md:px-3 md:py-3" : "py-3";
+	const sizeClass = size === "small" ? "px-2 py-1 md:px-3 md:py-1 text-sm" : size === "medium" ? "py-2" : "py-3";
 
 	const btnClass = `btn ${className ?? ""} ${sizeClass} ${
 		disabled || busy
@@ -46,7 +46,14 @@ export default function AppButton({
 	} ${width ?? "w-full"}`.trim();
 
 	const button = to ? (
-		<Link href={to} className={btnClass} onClick={(e) => { onClick(e); if (umamiEvent) track(umamiEvent); }}>
+		<Link
+			href={to}
+			className={btnClass}
+			onClick={(e) => {
+				onClick(e);
+				if (umamiEvent) track(umamiEvent);
+			}}
+		>
 			{children}
 		</Link>
 	) : (

--- a/components/AppButtonSecondary.tsx
+++ b/components/AppButtonSecondary.tsx
@@ -21,7 +21,7 @@ export default function AppButtonSecondary({
 	to,
 	isLoading,
 	className,
-	size,
+	size = "medium",
 	disabled,
 	width,
 	onClick = () => {},
@@ -31,7 +31,7 @@ export default function AppButtonSecondary({
 	note,
 	umamiEvent,
 }: Props) {
-	const sizeClass = size === "small" ? "px-2 py-1 md:px-3 md:py-1 text-sm" : size === "medium" ? "px-3 py-2 md:px-3 md:py-3" : "py-3";
+	const sizeClass = size === "small" ? "px-2 py-1 md:px-3 md:py-1 text-sm" : size === "medium" ? "py-2" : "py-3";
 
 	const btnClass = `btn ${className ?? ""} ${sizeClass} ${
 		disabled || isLoading
@@ -40,7 +40,14 @@ export default function AppButtonSecondary({
 	} ${width ?? "w-full"}`.trim();
 
 	const button = to ? (
-		<Link href={to} className={btnClass} onClick={(e) => { onClick(e); if (umamiEvent) track(umamiEvent); }}>
+		<Link
+			href={to}
+			className={btnClass}
+			onClick={(e) => {
+				onClick(e);
+				if (umamiEvent) track(umamiEvent);
+			}}
+		>
 			{children}
 		</Link>
 	) : (

--- a/components/Guards/GuardQualifiedVoter.tsx
+++ b/components/Guards/GuardQualifiedVoter.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { useConnection } from "wagmi";
+import { useAppKit } from "@reown/appkit/react";
+import AppButton from "@components/AppButton";
+import { useVotingPowers } from "../../hooks/useVotingPowers";
+
+const VETO_THRESHOLD = 0.02; // 2%
+
+interface Props {
+	children?: React.ReactNode;
+	disabled?: boolean;
+}
+
+export default function GuardQualifiedVoter({ children, disabled }: Props) {
+	const { isDisconnected } = useConnection();
+	const AppKit = useAppKit();
+	const { accountVoteData, isLoading } = useVotingPowers();
+
+	if (isDisconnected)
+		return (
+			<AppButton disabled={disabled} onClick={() => AppKit.open()}>
+				Connect Wallet
+			</AppButton>
+		);
+
+	if (isLoading)
+		return (
+			<AppButton disabled isLoading>
+				Loading...
+			</AppButton>
+		);
+
+	const combinedRatio = (accountVoteData?.votingPowerRatio ?? 0) + (accountVoteData?.supportedVotingPowerRatio ?? 0);
+	const isQualified = combinedRatio >= VETO_THRESHOLD;
+
+	if (!isQualified) return <AppButton disabled>Insufficient Votes</AppButton>;
+
+	return <>{children}</>;
+}

--- a/components/Guards/GuardSupportedChain.tsx
+++ b/components/Guards/GuardSupportedChain.tsx
@@ -44,7 +44,7 @@ export default function GuardSupportedChain({ children, label, disabled, chain, 
 	// Check if wallet is disconnected
 	if (Account.isDisconnected)
 		return (
-<AppButton
+			<AppButton
 				disabled={disabled}
 				onClick={() => {
 					AppKit.open();
@@ -58,7 +58,7 @@ export default function GuardSupportedChain({ children, label, disabled, chain, 
 	// Check if wallet is connected to the correct chains
 	if (!isCorrectChain)
 		return (
-<AppButton
+			<AppButton
 				disabled={disabled}
 				onClick={() => {
 					AppKitNetwork.switchNetwork(chain);

--- a/components/Guards/GuardToAllowedChainBtn.tsx
+++ b/components/Guards/GuardToAllowedChainBtn.tsx
@@ -31,7 +31,7 @@ export default function GuardToAllowedChainBtn(props: Props) {
 	// Check if wallet is disconnected
 	if (isDisconnected)
 		return (
-<AppButton
+			<AppButton
 				className="h-10"
 				disabled={props.disabled}
 				onClick={() => {
@@ -46,7 +46,7 @@ export default function GuardToAllowedChainBtn(props: Props) {
 	// Check if wallet is connected to one of the available chains
 	if (!isCorrectChain)
 		return (
-<AppButton
+			<AppButton
 				className="h-10"
 				disabled={props.disabled}
 				onClick={() => {

--- a/components/LoadingScreen.tsx
+++ b/components/LoadingScreen.tsx
@@ -58,6 +58,19 @@ export default function LoadingScreen({ title = "Frankencoin is loading...", loa
 						</ul>
 					)}
 
+					<p className="text-sm text-amber-600 border border-amber-300 bg-amber-50 rounded px-4 py-3 max-w-md text-center">
+						⚠️ The frontend is currently not getting any data due to a{" "}
+						<a
+							href="https://status.railway.com/incident/I23M92U0"
+							target="_blank"
+							rel="noreferrer"
+							className="underline hover:opacity-80"
+						>
+							service disruption
+						</a>
+						{" "}at our hosting provider.
+					</p>
+
 					{showWarning && (
 						<p className="text-sm text-text-warning animate-pulse text-center max-w-md">
 							Loading takes longer than expected. Continuing in {remainingSeconds}s. Please try again at a later point

--- a/components/PageGovernance/GovernanceCCIPAdminDenyAction.tsx
+++ b/components/PageGovernance/GovernanceCCIPAdminDenyAction.tsx
@@ -8,6 +8,7 @@ import AppButton from "@components/AppButton";
 import { Chain, Hash } from "viem";
 import { ADDRESS, CCIPAdminABI, ChainId, SupportedChainsMap } from "@frankencoin/zchf";
 import GuardSupportedChain from "@components/Guards/GuardSupportedChain";
+import GuardQualifiedVoter from "@components/Guards/GuardQualifiedVoter";
 import { useDelegationHelpers } from "@hooks";
 import { shortenString } from "@utils";
 import { ApiCCIPProposal } from "../../redux/slices/bridge.types";
@@ -62,10 +63,12 @@ export default function GovernanceCCIPAdminDenyAction({ proposal, disabled }: Pr
 	};
 
 	return (
-		<GuardSupportedChain disabled={isHidden || disabled} chain={chain}>
-			<AppButton className="" disabled={isHidden || disabled} isLoading={isDenying} onClick={handleOnClick}>
-				Deny
-			</AppButton>
-		</GuardSupportedChain>
+		<GuardQualifiedVoter disabled={isHidden || disabled}>
+			<GuardSupportedChain disabled={isHidden || disabled} chain={chain}>
+				<AppButton disabled={isHidden || disabled} isLoading={isDenying} onClick={handleOnClick}>
+					Deny
+				</AppButton>
+			</GuardSupportedChain>
+		</GuardQualifiedVoter>
 	);
 }

--- a/components/PageGovernance/GovernanceCCIPAdminDenyAction.tsx
+++ b/components/PageGovernance/GovernanceCCIPAdminDenyAction.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { waitForTransactionReceipt, writeContract } from "wagmi/actions";
+import { WAGMI_CONFIG } from "../../app.config";
+import { toast } from "react-toastify";
+import { renderErrorTxToastDecode, TxToast } from "@components/TxToast";
+import { useConnection } from "wagmi";
+import AppButton from "@components/AppButton";
+import { Chain, Hash } from "viem";
+import { ADDRESS, CCIPAdminABI, ChainId, SupportedChainsMap } from "@frankencoin/zchf";
+import GuardSupportedChain from "@components/Guards/GuardSupportedChain";
+import { useDelegationHelpers } from "@hooks";
+import { shortenString } from "@utils";
+import { ApiCCIPProposal } from "../../redux/slices/bridge.types";
+
+interface Props {
+	proposal: ApiCCIPProposal;
+	disabled?: boolean;
+}
+
+export default function GovernanceCCIPAdminDenyAction({ proposal, disabled }: Props) {
+	const [isDenying, setDenying] = useState(false);
+	const [isHidden, setHidden] = useState(false);
+	const account = useConnection();
+	const { helpers } = useDelegationHelpers(account.address);
+	const chain = SupportedChainsMap[proposal.chainId as ChainId] as Chain;
+
+	const handleOnClick = async (e: any) => {
+		e.preventDefault();
+		if (!account.address) return;
+
+		const ccipAdmin = ADDRESS[proposal.chainId as ChainId]?.ccipAdmin;
+		if (!ccipAdmin) return;
+
+		try {
+			setDenying(true);
+
+			const writeHash = await writeContract(WAGMI_CONFIG, {
+				address: ccipAdmin,
+				chainId: proposal.chainId,
+				abi: CCIPAdminABI,
+				functionName: "deny",
+				args: [proposal.hash as Hash, helpers],
+			});
+
+			const toastContent = [
+				{ title: "Proposal: ", value: shortenString(proposal.hash) },
+				{ title: "Type: ", value: proposal.type ?? "—" },
+				{ title: "Transaction: ", hash: writeHash },
+			];
+
+			await toast.promise(waitForTransactionReceipt(WAGMI_CONFIG, { hash: writeHash, confirmations: 1 }), {
+				pending: { render: <TxToast title="Denying proposal..." rows={toastContent} /> },
+				success: { render: <TxToast title="Proposal denied" rows={toastContent} /> },
+			});
+
+			setHidden(true);
+		} catch (error) {
+			toast.error(renderErrorTxToastDecode(error, CCIPAdminABI));
+		} finally {
+			setDenying(false);
+		}
+	};
+
+	return (
+		<GuardSupportedChain disabled={isHidden || disabled} chain={chain}>
+			<AppButton className="" disabled={isHidden || disabled} isLoading={isDenying} onClick={handleOnClick}>
+				Deny
+			</AppButton>
+		</GuardSupportedChain>
+	);
+}

--- a/components/PageGovernance/GovernanceCCIPAdminEnactAction.tsx
+++ b/components/PageGovernance/GovernanceCCIPAdminEnactAction.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { waitForTransactionReceipt, writeContract } from "wagmi/actions";
+import { WAGMI_CONFIG } from "../../app.config";
+import { toast } from "react-toastify";
+import { renderErrorTxToastDecode, TxToast } from "@components/TxToast";
+import { useConnection } from "wagmi";
+import AppButton from "@components/AppButton";
+import { Address, Chain } from "viem";
+import { ADDRESS, CCIPAdminABI, ChainId, SupportedChainsMap } from "@frankencoin/zchf";
+import GuardSupportedChain from "@components/Guards/GuardSupportedChain";
+import { shortenString } from "@utils";
+import { ApiCCIPProposal } from "../../redux/slices/bridge.types";
+
+interface Props {
+	proposal: ApiCCIPProposal;
+	disabled?: boolean;
+}
+
+function buildEnactCall(proposal: ApiCCIPProposal): { functionName: string; args: unknown[] } | null {
+	if (!proposal.details) return null;
+	try {
+		const d = JSON.parse(proposal.details);
+		switch (proposal.type) {
+			case "AddChain":
+				return {
+					functionName: "applyAddChain",
+					args: [
+						{
+							remoteChainSelector: BigInt(d.remoteChainSelector),
+							remotePoolAddresses: d.remotePoolAddresses as `0x${string}`[],
+							remoteTokenAddress: d.remoteTokenAddress as `0x${string}`,
+							outboundRateLimiterConfig: {
+								isEnabled: d.outboundRateLimiterConfig.isEnabled as boolean,
+								capacity: BigInt(d.outboundRateLimiterConfig.capacity),
+								rate: BigInt(d.outboundRateLimiterConfig.rate),
+							},
+							inboundRateLimiterConfig: {
+								isEnabled: d.inboundRateLimiterConfig.isEnabled as boolean,
+								capacity: BigInt(d.inboundRateLimiterConfig.capacity),
+								rate: BigInt(d.inboundRateLimiterConfig.rate),
+							},
+						},
+					],
+				};
+			case "RemoveChain":
+				return { functionName: "applyRemoveChain", args: [BigInt(d.chain)] };
+			case "RemotePoolUpdate":
+				return {
+					functionName: "applyRemotePoolUpdate",
+					args: [{ add: d.add as boolean, chain: BigInt(d.chain), poolAddress: d.poolAddress as `0x${string}` }],
+				};
+			case "AdminTransfer":
+				return { functionName: "applyAdminTransfer", args: [d.newAdmin as Address] };
+			default:
+				return null;
+		}
+	} catch {
+		return null;
+	}
+}
+
+export default function GovernanceCCIPAdminEnactAction({ proposal, disabled }: Props) {
+	const [isEnacting, setEnacting] = useState(false);
+	const [isHidden, setHidden] = useState(false);
+	const account = useConnection();
+	const chain = SupportedChainsMap[proposal.chainId as ChainId] as Chain;
+
+	const handleOnClick = async (e: any) => {
+		e.preventDefault();
+		if (!account.address) return;
+
+		const ccipAdmin = ADDRESS[proposal.chainId as ChainId]?.ccipAdmin;
+		if (!ccipAdmin) return;
+
+		const call = buildEnactCall(proposal);
+		if (!call) return;
+
+		try {
+			setEnacting(true);
+
+			const writeHash = await writeContract(WAGMI_CONFIG, {
+				address: ccipAdmin,
+				chainId: proposal.chainId,
+				abi: CCIPAdminABI,
+				functionName: call.functionName as any,
+				args: call.args as any,
+			});
+
+			const toastContent = [
+				{ title: "Proposal: ", value: shortenString(proposal.hash) },
+				{ title: "Type: ", value: proposal.type ?? "—" },
+				{ title: "Transaction: ", hash: writeHash },
+			];
+
+			await toast.promise(waitForTransactionReceipt(WAGMI_CONFIG, { hash: writeHash, confirmations: 1 }), {
+				pending: { render: <TxToast title="Enacting proposal..." rows={toastContent} /> },
+				success: { render: <TxToast title="Proposal enacted" rows={toastContent} /> },
+			});
+
+			setHidden(true);
+		} catch (error) {
+			toast.error(renderErrorTxToastDecode(error, CCIPAdminABI));
+		} finally {
+			setEnacting(false);
+		}
+	};
+
+	return (
+		<GuardSupportedChain disabled={isHidden || disabled} chain={chain}>
+			<AppButton disabled={isHidden || disabled} isLoading={isEnacting} onClick={handleOnClick}>
+				Enact
+			</AppButton>
+		</GuardSupportedChain>
+	);
+}

--- a/components/PageGovernance/GovernanceCCIPAdminRow.tsx
+++ b/components/PageGovernance/GovernanceCCIPAdminRow.tsx
@@ -1,0 +1,100 @@
+import TableRow from "../Table/TableRow";
+import AppLink from "@components/AppLink";
+import { ChainId, SupportedChain, SupportedChainsMap } from "@frankencoin/zchf";
+import { ApiCCIPProposal } from "../../redux/slices/bridge.types";
+import { ContractUrl, getChainByChainSelector, shortenAddress, TxUrl } from "@utils";
+import { Address, Hash } from "viem";
+
+interface Props {
+	headers: string[];
+	tab: string;
+	proposal: ApiCCIPProposal;
+}
+
+const TYPE_LABEL: Record<string, string> = {
+	AddChain: "Add Chain",
+	RemoveChain: "Remove Chain",
+	RemotePoolUpdate: "Pool Update",
+	AdminTransfer: "Admin Transfer",
+};
+
+function StatusCell({ proposal }: { proposal: ApiCCIPProposal }) {
+	const chain = SupportedChainsMap[proposal.chainId as ChainId] as SupportedChain;
+	if (proposal.status === "Denied" || proposal.status === "Enacted") {
+		return (
+			<AppLink
+				className=""
+				label={proposal.status}
+				href={TxUrl((proposal.deniedTxHash ?? proposal.enactedTxHash ?? "") as Hash, chain)}
+				external={true}
+			/>
+		);
+	}
+
+	const msLeft = proposal.deadline * 1000 - Date.now();
+	const hoursLeft = msLeft / 1000 / 60 / 60;
+	const countdown = msLeft <= 0 ? "Expired" : hoursLeft < 24 ? `${Math.round(hoursLeft)}h left` : `${Math.round(hoursLeft / 24)}d left`;
+	return <span>{countdown}</span>;
+}
+
+function TypeCell({ proposal }: { proposal: ApiCCIPProposal }) {
+	let detail: string | null = null;
+	if (proposal.details) {
+		try {
+			const d = JSON.parse(proposal.details);
+			if (proposal.type === "AddChain" || proposal.type === "RemoveChain") {
+				const selector = d.remoteChainSelector ?? d.chain;
+				detail = getChainByChainSelector(String(selector))?.name ?? `#${selector}`;
+			} else if (proposal.type === "RemotePoolUpdate") {
+				const chainName = getChainByChainSelector(String(d.chain))?.name ?? `#${d.chain}`;
+				detail = `${d.add ? "+" : "−"} ${chainName}`;
+			} else if (proposal.type === "AdminTransfer" && d.newAdmin) {
+				detail = shortenAddress(d.newAdmin as Address);
+			}
+		} catch {}
+	}
+	return (
+		<div className="flex flex-col">
+			<span>{TYPE_LABEL[proposal.type ?? ""] ?? proposal.type ?? "—"}</span>
+			{detail && <span className="text-text-secondary text-sm">{detail}</span>}
+		</div>
+	);
+}
+
+export default function GovernanceCCIPAdminRow({ headers, tab, proposal }: Props) {
+	const chain = SupportedChainsMap[proposal.chainId as ChainId] as SupportedChain;
+	const dateArr = new Date(proposal.created * 1000).toDateString().split(" ");
+	const dateStr = `${dateArr[2]} ${dateArr[1]} ${dateArr[3]}`;
+
+	return (
+		<TableRow headers={headers} rawHeader={true} tab={tab} actionCol={<span />}>
+			{/* Date → tx link */}
+			<div className="flex flex-col md:text-left max-md:text-right">
+				<AppLink className="" label={dateStr} href={TxUrl(proposal.txHash as Hash, chain)} external={true} />
+			</div>
+
+			{/* Proposer → address link */}
+			<div className="flex flex-col">
+				{proposal.proposer ? (
+					<AppLink
+						className=""
+						label={shortenAddress(proposal.proposer as Address)}
+						href={ContractUrl(proposal.proposer, chain)}
+						external={true}
+					/>
+				) : (
+					<span className="text-text-secondary">—</span>
+				)}
+			</div>
+
+			{/* Chain (local chain where CCIPAdmin lives) */}
+			<div className="flex flex-col">{chain?.name ?? proposal.chainId}</div>
+
+			{/* Type + target chain detail */}
+			<TypeCell proposal={proposal} />
+
+			{/* Status: date/countdown + badge */}
+			<StatusCell proposal={proposal} />
+		</TableRow>
+	);
+}

--- a/components/PageGovernance/GovernanceCCIPAdminRow.tsx
+++ b/components/PageGovernance/GovernanceCCIPAdminRow.tsx
@@ -35,7 +35,7 @@ function StatusCell({ proposal }: { proposal: ApiCCIPProposal }) {
 
 	const msLeft = proposal.deadline * 1000 - Date.now();
 	const hoursLeft = msLeft / 1000 / 60 / 60;
-	const countdown = msLeft <= 0 ? "Expired" : hoursLeft < 24 ? `${Math.round(hoursLeft)}h left` : `${Math.round(hoursLeft / 24)}d left`;
+	const countdown = msLeft <= 0 ? "Ready" : hoursLeft < 24 ? `${Math.round(hoursLeft)}h left` : `${Math.round(hoursLeft / 24)}d left`;
 	return <span>{countdown}</span>;
 }
 

--- a/components/PageGovernance/GovernanceCCIPAdminRow.tsx
+++ b/components/PageGovernance/GovernanceCCIPAdminRow.tsx
@@ -4,6 +4,8 @@ import { ChainId, SupportedChain, SupportedChainsMap } from "@frankencoin/zchf";
 import { ApiCCIPProposal } from "../../redux/slices/bridge.types";
 import { ContractUrl, getChainByChainSelector, shortenAddress, TxUrl } from "@utils";
 import { Address, Hash } from "viem";
+import GovernanceCCIPAdminDenyAction from "./GovernanceCCIPAdminDenyAction";
+import GovernanceCCIPAdminEnactAction from "./GovernanceCCIPAdminEnactAction";
 
 interface Props {
 	headers: string[];
@@ -66,8 +68,21 @@ export default function GovernanceCCIPAdminRow({ headers, tab, proposal }: Props
 	const dateArr = new Date(proposal.created * 1000).toDateString().split(" ");
 	const dateStr = `${dateArr[2]} ${dateArr[1]} ${dateArr[3]}`;
 
+	const isPending = proposal.status === "Pending";
+	const deadlinePassed = proposal.deadline * 1000 < Date.now();
+
+	const actionCol = isPending ? (
+		deadlinePassed ? (
+			<GovernanceCCIPAdminEnactAction proposal={proposal} />
+		) : (
+			<GovernanceCCIPAdminDenyAction proposal={proposal} />
+		)
+	) : (
+		<span />
+	);
+
 	return (
-		<TableRow headers={headers} rawHeader={true} tab={tab} actionCol={<span />}>
+		<TableRow headers={headers} rawHeader={true} tab={tab} actionCol={actionCol}>
 			{/* Date → tx link */}
 			<div className="flex flex-col md:text-left max-md:text-right">
 				<AppLink className="" label={dateStr} href={TxUrl(proposal.txHash as Hash, chain)} external={true} />

--- a/components/PageGovernance/GovernanceCCIPAdminTable.tsx
+++ b/components/PageGovernance/GovernanceCCIPAdminTable.tsx
@@ -1,0 +1,77 @@
+import Table from "../Table";
+import TableBody from "../Table/TableBody";
+import TableHeader from "../Table/TableHead";
+import TableRowEmpty from "../Table/TableRowEmpty";
+import { useMemo, useState } from "react";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/redux.store";
+import GovernanceCCIPAdminRow from "./GovernanceCCIPAdminRow";
+
+const STATUS_OPTIONS = ["All", "Pending", "Enacted", "Denied"];
+
+export default function GovernanceCCIPAdminTable() {
+	const proposals = useSelector((state: RootState) => state.bridge.proposals);
+	const loaded = useSelector((state: RootState) => state.bridge.loaded);
+
+	const headers = ["Date", "Proposer", "Chain", "Type", "Status"];
+	const [tab, setTab] = useState(headers[0]);
+	const [reverse, setReverse] = useState(false);
+	const [statusFilter, setStatusFilter] = useState("All");
+
+	const handleTabOnChange = (e: string) => {
+		if (tab === e) setReverse(!reverse);
+		else {
+			setReverse(false);
+			setTab(e);
+		}
+	};
+
+	const sorted = useMemo(() => {
+		const filtered = statusFilter === "All" ? proposals : proposals.filter((p) => p.status === statusFilter);
+		return [...filtered].sort((a, b) => {
+			let cmp = 0;
+			if (tab === "Date") cmp = a.created - b.created;
+			else if (tab === "Chain") cmp = a.chainId - b.chainId;
+			else if (tab === "Type") cmp = (a.type ?? "").localeCompare(b.type ?? "");
+			else if (tab === "Status") cmp = a.status.localeCompare(b.status);
+			return reverse ? -cmp : cmp;
+		});
+	}, [proposals, tab, reverse, statusFilter]);
+
+	return (
+		<Table>
+			<div className="rounded-t-lg bg-table-header-primary">
+				<div className="flex flex-wrap items-center gap-2 px-8 xl:px-12 py-3 border-b border-table-header-secondary">
+					<div className="flex items-center gap-2 ml-auto">
+						<span className="text-sm font-semibold text-text-secondary">Status</span>
+						<div className="flex gap-1">
+							{STATUS_OPTIONS.map((s) => (
+								<button
+									key={s}
+									onClick={() => setStatusFilter(s)}
+									className={`px-3 py-1 rounded text-xs font-semibold transition-colors ${
+										statusFilter === s
+											? "bg-button-default text-white"
+											: "bg-white text-text-secondary border border-gray-200 hover:border-gray-400"
+									}`}
+								>
+									{s}
+								</button>
+							))}
+						</div>
+					</div>
+				</div>
+				<TableHeader headers={headers} tab={tab} reverse={reverse} tabOnChange={handleTabOnChange} actionCol />
+			</div>
+			<TableBody>
+				{sorted.length === 0 ? (
+					<TableRowEmpty>{loaded ? "No proposals found." : "Loading..."}</TableRowEmpty>
+				) : (
+					sorted.map((p) => (
+						<GovernanceCCIPAdminRow key={`${p.chainId}-${p.hash}`} headers={headers} tab={tab} proposal={p} />
+					))
+				)}
+			</TableBody>
+		</Table>
+	);
+}

--- a/components/PageGovernance/GovernanceLeadrateActionMint.tsx
+++ b/components/PageGovernance/GovernanceLeadrateActionMint.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react";
+import { useConnection } from "wagmi";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/redux.store";
+import { WAGMI_CONFIG } from "../../app.config";
+import { waitForTransactionReceipt, writeContract } from "wagmi/actions";
+import { ADDRESS, EquityABI, SavingsABI } from "@frankencoin/zchf";
+import { renderErrorTxToastDecode, TxToast } from "@components/TxToast";
+import { toast } from "react-toastify";
+import AppButton from "@components/AppButton";
+import NormalInput from "@components/Input/NormalInput";
+import GuardSupportedChain from "@components/Guards/GuardSupportedChain";
+import GuardQualifiedVoter from "@components/Guards/GuardQualifiedVoter";
+import { useDelegationHelpers } from "@hooks";
+import { formatCurrency, normalizeAddress } from "../../utils/format";
+import { mainnet } from "viem/chains";
+import { Address } from "viem";
+
+const Module = normalizeAddress(ADDRESS[mainnet.id].savingsV2);
+
+const UINT40_MAX = 2n ** 40n - 1n;
+
+function calcOverflowWarning(rate: number, created: number): string | null {
+	if (rate <= 0) return null;
+	const maxElapsed = Number(UINT40_MAX / BigInt(rate));
+	const overflowTs = created + maxElapsed;
+	const now = Math.floor(Date.now() / 1000);
+	if (overflowTs <= now) return "Contract is bricked: uint40 overflow reached, rate changes will permanently revert.";
+	const daysLeft = Math.floor((overflowTs - now) / 86400);
+	if (daysLeft >= 90) return null;
+	const d = new Date(overflowTs * 1000);
+	return `Apply new rate before ${d.getDate()}.${d.getMonth() + 1}.${d.getFullYear()} (~${daysLeft}d) due to uint40 overflow in contract.`;
+}
+
+export default function GovernanceLeadrateActionMint() {
+	const account = useConnection();
+	const { helpers } = useDelegationHelpers(account.address);
+	const rate = useSelector((state: RootState) => state.savings.leadrateRate.rate[mainnet.id]);
+
+	const current = rate[Module];
+	const [newRate, setNewRate] = useState<bigint>(BigInt(current.approvedRate));
+	const [isHandling, setHandling] = useState(false);
+	const [isHidden, setHidden] = useState(false);
+	const [isDisabled, setDisabled] = useState(true);
+
+	useEffect(() => {
+		setDisabled(newRate === BigInt(rate[Module].approvedRate));
+	}, [newRate, rate]);
+
+	const overflowWarning = calcOverflowWarning(current.approvedRate, current.created);
+
+	const handleOnClick = async (e: any) => {
+		e.preventDefault();
+		if (!account.address) return;
+		try {
+			setHandling(true);
+			const writeHash = await writeContract(WAGMI_CONFIG, {
+				address: Module as Address,
+				chainId: mainnet.id,
+				abi: SavingsABI,
+				functionName: "proposeChange",
+				args: [parseInt(String(newRate)), helpers],
+			});
+			const toastContent = [
+				{ title: "From: ", value: `${formatCurrency(current.approvedRate / 10000)}%` },
+				{ title: "Proposing to: ", value: `${formatCurrency(parseInt(String(newRate)) / 10000)}%` },
+				{ title: "Transaction: ", hash: writeHash },
+			];
+			await toast.promise(waitForTransactionReceipt(WAGMI_CONFIG, { hash: writeHash, confirmations: 1 }), {
+				pending: { render: <TxToast title="Proposing mint rate change..." rows={toastContent} /> },
+				success: { render: <TxToast title="Successfully proposed" rows={toastContent} /> },
+			});
+			setHidden(true);
+		} catch (error) {
+			toast.error(renderErrorTxToastDecode(error, EquityABI));
+		} finally {
+			setHandling(false);
+		}
+	};
+
+	return (
+		<>
+			<NormalInput
+				symbol="%"
+				label="Mint Rate"
+				placeholder="Change Rate"
+				value={newRate.toString()}
+				digit={4}
+				onChange={(e) => setNewRate(BigInt(e))}
+				warning={overflowWarning ?? undefined}
+			/>
+			<div className="h-10 mb-4">
+				<GuardQualifiedVoter disabled={isDisabled || isHidden}>
+					<GuardSupportedChain disabled={isDisabled || isHidden} chain={mainnet}>
+						<AppButton disabled={isDisabled || isHidden} isLoading={isHandling} onClick={handleOnClick}>
+							Propose Change
+						</AppButton>
+					</GuardSupportedChain>
+				</GuardQualifiedVoter>
+			</div>
+		</>
+	);
+}

--- a/components/PageGovernance/GovernanceLeadrateActionSave.tsx
+++ b/components/PageGovernance/GovernanceLeadrateActionSave.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react";
+import { useConnection } from "wagmi";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/redux.store";
+import { WAGMI_CONFIG } from "../../app.config";
+import { waitForTransactionReceipt, writeContract } from "wagmi/actions";
+import { ADDRESS, EquityABI, SavingsABI } from "@frankencoin/zchf";
+import { renderErrorTxToastDecode, TxToast } from "@components/TxToast";
+import { toast } from "react-toastify";
+import AppButton from "@components/AppButton";
+import NormalInput from "@components/Input/NormalInput";
+import GuardSupportedChain from "@components/Guards/GuardSupportedChain";
+import GuardQualifiedVoter from "@components/Guards/GuardQualifiedVoter";
+import { useDelegationHelpers } from "@hooks";
+import { formatCurrency, normalizeAddress } from "../../utils/format";
+import { mainnet } from "viem/chains";
+import { Address } from "viem";
+
+const Module = normalizeAddress(ADDRESS[mainnet.id].savingsReferral);
+
+const UINT40_MAX = 2n ** 40n - 1n;
+
+function calcOverflowWarning(rate: number, created: number): string | null {
+	if (rate <= 0) return null;
+	const maxElapsed = Number(UINT40_MAX / BigInt(rate));
+	const overflowTs = created + maxElapsed;
+	const now = Math.floor(Date.now() / 1000);
+	if (overflowTs <= now) return "Contract is bricked: uint40 overflow reached, rate changes will permanently revert.";
+	const daysLeft = Math.floor((overflowTs - now) / 86400);
+	if (daysLeft >= 90) return null;
+	const d = new Date(overflowTs * 1000);
+	return `Apply new rate before ${d.getDate()}.${d.getMonth() + 1}.${d.getFullYear()} (~${daysLeft}d) due to uint40 overflow in contract.`;
+}
+
+export default function GovernanceLeadrateActionSave() {
+	const account = useConnection();
+	const { helpers } = useDelegationHelpers(account.address);
+	const rate = useSelector((state: RootState) => state.savings.leadrateRate.rate[mainnet.id]);
+
+	const current = rate[Module];
+	const [newRate, setNewRate] = useState<bigint>(BigInt(current.approvedRate));
+	const [isHandling, setHandling] = useState(false);
+	const [isHidden, setHidden] = useState(false);
+	const [isDisabled, setDisabled] = useState(true);
+
+	useEffect(() => {
+		setDisabled(newRate === BigInt(rate[Module].approvedRate));
+	}, [newRate, rate]);
+
+	const overflowWarning = calcOverflowWarning(current.approvedRate, current.created);
+
+	const handleOnClick = async (e: any) => {
+		e.preventDefault();
+		if (!account.address) return;
+		try {
+			setHandling(true);
+			const writeHash = await writeContract(WAGMI_CONFIG, {
+				address: Module as Address,
+				chainId: mainnet.id,
+				abi: SavingsABI,
+				functionName: "proposeChange",
+				args: [parseInt(String(newRate)), helpers],
+			});
+			const toastContent = [
+				{ title: "From: ", value: `${formatCurrency(current.approvedRate / 10000)}%` },
+				{ title: "Proposing to: ", value: `${formatCurrency(parseInt(String(newRate)) / 10000)}%` },
+				{ title: "Transaction: ", hash: writeHash },
+			];
+			await toast.promise(waitForTransactionReceipt(WAGMI_CONFIG, { hash: writeHash, confirmations: 1 }), {
+				pending: { render: <TxToast title="Proposing save rate change..." rows={toastContent} /> },
+				success: { render: <TxToast title="Successfully proposed" rows={toastContent} /> },
+			});
+			setHidden(true);
+		} catch (error) {
+			toast.error(renderErrorTxToastDecode(error, EquityABI));
+		} finally {
+			setHandling(false);
+		}
+	};
+
+	return (
+		<>
+			<NormalInput
+				symbol="%"
+				label="Save Rate"
+				placeholder="Change Rate"
+				value={newRate.toString()}
+				digit={4}
+				onChange={(e) => setNewRate(BigInt(e))}
+				warning={overflowWarning ?? undefined}
+			/>
+			<div className="h-10 mb-4">
+				<GuardQualifiedVoter disabled={isDisabled || isHidden}>
+					<GuardSupportedChain disabled={isDisabled || isHidden} chain={mainnet}>
+						<AppButton disabled={isDisabled || isHidden} isLoading={isHandling} onClick={handleOnClick}>
+							Propose Change
+						</AppButton>
+					</GuardSupportedChain>
+				</GuardQualifiedVoter>
+			</div>
+		</>
+	);
+}

--- a/components/PageGovernance/GovernanceLeadrateCurrent.tsx
+++ b/components/PageGovernance/GovernanceLeadrateCurrent.tsx
@@ -1,56 +1,22 @@
-import { formatCurrency } from "../../utils/format";
-import AppButton from "@components/AppButton";
-import NormalInput from "@components/Input/NormalInput";
 import AppCard from "@components/AppCard";
 import { useSelector } from "react-redux";
 import { RootState } from "../../redux/redux.store";
-import { useEffect, useState } from "react";
-import { useConnection } from "wagmi";
-import { WAGMI_CONFIG } from "../../app.config";
-import { waitForTransactionReceipt, writeContract } from "wagmi/actions";
-import { ADDRESS, EquityABI, SavingsABI } from "@frankencoin/zchf";
-import { renderErrorTxToastDecode, TxToast } from "@components/TxToast";
-import { toast } from "react-toastify";
+import { ADDRESS } from "@frankencoin/zchf";
 import dynamic from "next/dynamic";
 import { LeadrateRateQuery } from "@frankencoin/api";
 import { mainnet } from "viem/chains";
-import GuardSupportedChain from "@components/Guards/GuardSupportedChain";
-import { Address } from "viem";
 import { normalizeAddress } from "../../utils/format";
-import { useDelegationHelpers } from "@hooks";
+import GovernanceLeadrateActionMint from "./GovernanceLeadrateActionMint";
+import GovernanceLeadrateActionSave from "./GovernanceLeadrateActionSave";
 const ApexChart = dynamic(() => import("react-apexcharts"), { ssr: false });
 
 const MintModule = normalizeAddress(ADDRESS[mainnet.id].savingsV2);
 const SaveModule = normalizeAddress(ADDRESS[mainnet.id].savingsReferral);
 
-interface Props {}
-
-export default function GovernanceLeadrateCurrent({}: Props) {
-	const account = useConnection();
+export default function GovernanceLeadrateCurrent() {
 	const chainId = mainnet.id;
-	const { helpers } = useDelegationHelpers(account.address);
 	const rate = useSelector((state: RootState) => state.savings.leadrateRate.rate[chainId]);
 	const rates = useSelector((state: RootState) => state.savings.leadrateRate.list[chainId]);
-
-	const [newRateMint, setNewRateMint] = useState<bigint>(BigInt(rate[MintModule].approvedRate));
-	const [isHandlingMint, setHandlingMint] = useState<boolean>(false);
-	const [isHiddenMint, setHiddenMint] = useState<boolean>(false);
-	const [isDisabledMint, setDisabledMint] = useState<boolean>(true);
-
-	const [newRateSave, setNewRateSave] = useState<bigint>(BigInt(rate[SaveModule].approvedRate));
-	const [isHandlingSave, setHandlingSave] = useState<boolean>(false);
-	const [isHiddenSave, setHiddenSave] = useState<boolean>(false);
-	const [isDisabledSave, setDisabledSave] = useState<boolean>(true);
-
-	useEffect(() => {
-		if (newRateMint != BigInt(rate[MintModule].approvedRate)) setDisabledMint(false);
-		else setDisabledMint(true);
-	}, [newRateMint, rate]);
-
-	useEffect(() => {
-		if (newRateSave != BigInt(rate[SaveModule].approvedRate)) setDisabledSave(false);
-		else setDisabledSave(true);
-	}, [newRateSave, rate]);
 
 	const latestDefaultEntryMint: LeadrateRateQuery = {
 		chainId: mainnet.id,
@@ -75,125 +41,6 @@ export default function GovernanceLeadrateCurrent({}: Props) {
 	const matchingRatesMint = [latestDefaultEntryMint, ...rates[MintModule]];
 	const matchingRatesSave = [latestDefaultEntrySave, ...rates[SaveModule]];
 
-	// Bug in AbstractLeadrate.sol line 40: uint40 overflow in updateRate().
-	// ticksAnchor += (timeNow - anchorTime) * currentRatePPM overflows uint40
-	// when (elapsed seconds) * ratePPM > 2^40 - 1.
-	// Each rate change resets the countdown. After the deadline, any updateRate() call will revert.
-	const UINT40_MAX = 2n ** 40n - 1n;
-	const calcOverflowTimestamp = (module: Address) => {
-		const ratePPM = rate[module].approvedRate;
-		if (ratePPM <= 0) return null;
-		const anchor = rate[module].created;
-		const maxElapsed = Number(UINT40_MAX / BigInt(ratePPM));
-		return anchor + maxElapsed;
-	};
-	const formatOverflowWarning = (overflowTs: number | null) => {
-		if (!overflowTs) return null;
-		const now = Math.floor(Date.now() / 1000);
-		if (overflowTs <= now) return "Contract is bricked: uint40 overflow reached, rate changes will permanently revert.";
-		const daysLeft = Math.floor((overflowTs - now) / 86400);
-		const date = new Date(overflowTs * 1000);
-		const dateStr = `${date.getDate()}.${date.getMonth() + 1}.${date.getFullYear()}`;
-		if (daysLeft < 90) return `Apply new rate before ${dateStr} (~${daysLeft}d) due to uint40 overflow in contract.`;
-		return null;
-	};
-	const overflowWarningMint = formatOverflowWarning(calcOverflowTimestamp(MintModule));
-	const overflowWarningSave = formatOverflowWarning(calcOverflowTimestamp(SaveModule));
-
-	const handleOnClickMint = async function (e: any) {
-		e.preventDefault();
-		if (!account.address) return;
-
-		try {
-			setHandlingMint(true);
-
-			const writeHash = await writeContract(WAGMI_CONFIG, {
-				address: MintModule,
-				chainId: chainId,
-				abi: SavingsABI,
-				functionName: "proposeChange",
-				args: [parseInt(String(newRateMint)), helpers],
-			});
-
-			const toastContent = [
-				{
-					title: `From: `,
-					value: `${formatCurrency(rate[MintModule].approvedRate / 10000)}%`,
-				},
-				{
-					title: `Proposing to: `,
-					value: `${formatCurrency(parseInt(String(newRateMint)) / 10000)}%`,
-				},
-				{
-					title: "Transaction: ",
-					hash: writeHash,
-				},
-			];
-
-			await toast.promise(waitForTransactionReceipt(WAGMI_CONFIG, { hash: writeHash, confirmations: 1 }), {
-				pending: {
-					render: <TxToast title={`Proposing mint rate change...`} rows={toastContent} />,
-				},
-				success: {
-					render: <TxToast title="Successfully proposed" rows={toastContent} />,
-				},
-			});
-
-			setHiddenMint(true);
-		} catch (error) {
-			toast.error(renderErrorTxToastDecode(error, EquityABI));
-		} finally {
-			setHandlingMint(false);
-		}
-	};
-
-	const handleOnClickSave = async function (e: any) {
-		e.preventDefault();
-		if (!account.address) return;
-
-		try {
-			setHandlingSave(true);
-
-			const writeHash = await writeContract(WAGMI_CONFIG, {
-				address: SaveModule,
-				chainId: chainId,
-				abi: SavingsABI,
-				functionName: "proposeChange",
-				args: [parseInt(String(newRateSave)), helpers],
-			});
-
-			const toastContent = [
-				{
-					title: `From: `,
-					value: `${formatCurrency(rate[SaveModule].approvedRate / 10000)}%`,
-				},
-				{
-					title: `Proposing to: `,
-					value: `${formatCurrency(parseInt(String(newRateSave)) / 10000)}%`,
-				},
-				{
-					title: "Transaction: ",
-					hash: writeHash,
-				},
-			];
-
-			await toast.promise(waitForTransactionReceipt(WAGMI_CONFIG, { hash: writeHash, confirmations: 1 }), {
-				pending: {
-					render: <TxToast title={`Proposing save rate change...`} rows={toastContent} />,
-				},
-				success: {
-					render: <TxToast title="Successfully proposed" rows={toastContent} />,
-				},
-			});
-
-			setHiddenSave(true);
-		} catch (error) {
-			toast.error(renderErrorTxToastDecode(error, EquityABI));
-		} finally {
-			setHandlingSave(false);
-		}
-	};
-
 	return (
 		<div className="grid grid-cols-1 md:grid-cols-2 gap-2">
 			<AppCard>
@@ -203,91 +50,55 @@ export default function GovernanceLeadrateCurrent({}: Props) {
 					<ApexChart
 						type="line"
 						options={{
-							theme: {
-								monochrome: {
-									enabled: false,
-								},
-							},
+							theme: { monochrome: { enabled: false } },
 							colors: ["#092f62", "#0F80F0"],
-							stroke: {
-								curve: "linestep",
-								width: 3,
-							},
+							stroke: { curve: "linestep", width: 3 },
 							chart: {
 								type: "line",
 								height: 100,
-								dropShadow: {
-									enabled: false,
-								},
-								toolbar: {
-									show: false,
-								},
-								zoom: {
-									enabled: false,
-								},
+								dropShadow: { enabled: false },
+								toolbar: { show: false },
+								zoom: { enabled: false },
 								background: "0",
 							},
-							dataLabels: {
-								enabled: false,
-							},
-							grid: {
-								show: false,
-							},
+							dataLabels: { enabled: false },
+							grid: { show: false },
 							xaxis: {
 								type: "datetime",
 								labels: {
 									show: true,
 									formatter: (value) => {
-										const date = new Date(value);
-										const d = date.getDate();
-										const m = date.getMonth() + 1;
-										const y = date.getFullYear();
-										return `${d}.${m}.${y}`;
+										const d = new Date(value);
+										return `${d.getDate()}.${d.getMonth() + 1}.${d.getFullYear()}`;
 									},
 								},
-								axisBorder: {
-									show: false,
-								},
-								axisTicks: {
-									show: false,
-								},
+								axisBorder: { show: false },
+								axisTicks: { show: false },
 							},
 							yaxis: {
 								labels: {
 									show: true,
-									formatter: (value) => {
-										return `${Math.round(value / 1000) / 10} %`;
-									},
+									formatter: (value) => `${Math.round(value / 1000) / 10} %`,
 								},
-								axisBorder: {
-									show: true,
-								},
-								axisTicks: {
-									show: true,
-								},
+								axisBorder: { show: true },
+								axisTicks: { show: true },
 								min: 0,
-								max: (max) => {
-									return (Math.floor(max / 100000) + 1) * 50000;
-								},
+								max: (max) => (Math.floor(max / 100000) + 1) * 50000,
 							},
 						}}
 						series={[
 							{
 								name: "Mint",
-								data: matchingRatesMint.map((entry) => {
-									return [entry.created * 1000, Math.round(entry.approvedRate)];
-								}),
+								data: matchingRatesMint.map((e) => [e.created * 1000, Math.round(e.approvedRate)]),
 							},
 							{
 								name: "Save",
-								data: matchingRatesSave.map((entry) => {
-									return [entry.created * 1000, Math.round(entry.approvedRate)];
-								}),
+								data: matchingRatesSave.map((e) => [e.created * 1000, Math.round(e.approvedRate)]),
 							},
 						]}
 					/>
 
-					{matchingRatesMint.length == 0 || matchingRatesSave.length == 0 ? (
+					{matchingRatesMint.length === 0 || matchingRatesSave.length === 0 ? (
 						<div className="flex justify-center text-text-warning">No data available for selected timeframe.</div>
 					) : null}
 				</div>
@@ -296,50 +107,8 @@ export default function GovernanceLeadrateCurrent({}: Props) {
 			<AppCard>
 				<div className="flex flex-col gap-4">
 					<div className="mt-4 text-lg font-bold text-center">Propose a new Rate</div>
-
-					<NormalInput
-						symbol="%"
-						label="Mint Rate"
-						placeholder={`Change Rate`}
-						value={newRateMint.toString()}
-						digit={4}
-						onChange={(e) => setNewRateMint(BigInt(e))}
-						warning={overflowWarningMint ?? undefined}
-					/>
-
-					<div className="h-10 mb-4">
-						<GuardSupportedChain disabled={isDisabledMint || isHiddenMint} chain={mainnet}>
-<AppButton
-								disabled={isDisabledMint || isHiddenMint}
-								isLoading={isHandlingMint}
-								onClick={(e) => handleOnClickMint(e)}
-							>
-								Propose Change
-							</AppButton>
-						</GuardSupportedChain>
-					</div>
-
-					<NormalInput
-						symbol="%"
-						label="Save Rate"
-						placeholder={`Change Rate`}
-						value={newRateSave.toString()}
-						digit={4}
-						onChange={(e) => setNewRateSave(BigInt(e))}
-						warning={overflowWarningSave ?? undefined}
-					/>
-
-					<div className="h-10 mb-4">
-						<GuardSupportedChain disabled={isDisabledSave || isHiddenSave} chain={mainnet}>
-<AppButton
-								disabled={isDisabledSave || isHiddenSave}
-								isLoading={isHandlingSave}
-								onClick={(e) => handleOnClickSave(e)}
-							>
-								Propose Change
-							</AppButton>
-						</GuardSupportedChain>
-					</div>
+					<GovernanceLeadrateActionMint />
+					<GovernanceLeadrateActionSave />
 				</div>
 			</AppCard>
 		</div>

--- a/components/PageGovernance/GovernanceMintersAction.tsx
+++ b/components/PageGovernance/GovernanceMintersAction.tsx
@@ -19,6 +19,7 @@ import {
 	SupportedChainsMap,
 } from "@frankencoin/zchf";
 import GuardSupportedChain from "@components/Guards/GuardSupportedChain";
+import GuardQualifiedVoter from "@components/Guards/GuardQualifiedVoter";
 import { useDelegationHelpers } from "@hooks";
 
 interface Props {
@@ -85,12 +86,12 @@ export default function GovernanceMintersAction({ minter, disabled }: Props) {
 	};
 
 	return (
-		<div className="">
+		<GuardQualifiedVoter disabled={isHidden || disabled}>
 			<GuardSupportedChain disabled={isHidden || disabled} chain={SupportedChainsMap[chainId] as Chain}>
 				<AppButton className="h-10" disabled={isHidden || disabled} isLoading={isVetoing} onClick={(e) => handleOnClick(e)}>
 					Veto
 				</AppButton>
 			</GuardSupportedChain>
-		</div>
+		</GuardQualifiedVoter>
 	);
 }

--- a/components/PageGovernance/GovernancePositionsAction.tsx
+++ b/components/PageGovernance/GovernancePositionsAction.tsx
@@ -10,6 +10,7 @@ import { Address } from "viem";
 import { PositionQuery } from "@frankencoin/api";
 import { EquityABI, PositionV1ABI, PositionV2ABI } from "@frankencoin/zchf";
 import GuardSupportedChain from "@components/Guards/GuardSupportedChain";
+import GuardQualifiedVoter from "@components/Guards/GuardQualifiedVoter";
 import { mainnet } from "viem/chains";
 import { useDelegationHelpers } from "@hooks";
 
@@ -75,12 +76,12 @@ export default function GovernancePositionsAction({ position, disabled }: Props)
 	};
 
 	return (
-		<div className="">
+		<GuardQualifiedVoter disabled={isHidden || disabled}>
 			<GuardSupportedChain disabled={isHidden || disabled} chain={mainnet}>
 				<AppButton className="h-10" disabled={isHidden || disabled} isLoading={isDenying} onClick={(e) => handleOnClick(e)}>
 					Deny
 				</AppButton>
 			</GuardSupportedChain>
-		</div>
+		</GuardQualifiedVoter>
 	);
 }

--- a/components/PageMonitoring/AuctionBidAction.tsx
+++ b/components/PageMonitoring/AuctionBidAction.tsx
@@ -137,7 +137,10 @@ export default function AuctionBidAction({ position, challenge, auctionPrice, on
 				},
 			});
 
-			track("auction_bid_placed", { collateral: position.collateralSymbol, amount: formatBigInt(amount, position.collateralDecimals) });
+			track("auction_bid_placed", {
+				collateral: position.collateralSymbol,
+				amount: formatBigInt(amount, position.collateralDecimals),
+			});
 			onBidSuccess();
 		} catch (error) {
 			toast.error(renderErrorTxToast(error));
@@ -190,7 +193,12 @@ export default function AuctionBidAction({ position, challenge, auctionPrice, on
 				</div>
 				<div className="flex justify-between items-center">
 					<span className="text-text-secondary">Challenger</span>
-					<AppLink label={shortenAddress(challenge.challenger)} href={ContractUrl(challenge.challenger, WAGMI_CHAIN)} external={true} />
+					<AppLink
+						className=""
+						label={shortenAddress(challenge.challenger)}
+						href={ContractUrl(challenge.challenger, WAGMI_CHAIN)}
+						external={true}
+					/>
 				</div>
 				<div className="flex justify-between items-center">
 					<span className="text-text-secondary">Your balance</span>
@@ -203,7 +211,11 @@ export default function AuctionBidAction({ position, challenge, auctionPrice, on
 			</div>
 
 			<GuardSupportedChain chain={mainnet}>
-				<AppButton disabled={amount == 0n || expectedZCHF > userBalance || error != ""} isLoading={isBidding} onClick={() => handleBid()}>
+				<AppButton
+					disabled={amount == 0n || expectedZCHF > userBalance || error != ""}
+					isLoading={isBidding}
+					onClick={() => handleBid()}
+				>
 					Buy
 				</AppButton>
 			</GuardSupportedChain>

--- a/components/PageMonitoring/AuctionBidAction.tsx
+++ b/components/PageMonitoring/AuctionBidAction.tsx
@@ -20,12 +20,12 @@ import { mainnet } from "viem/chains";
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 function fmtDate(d: Date): string {
-	const day = d.getUTCDate();
-	const mon = MONTHS[d.getUTCMonth()];
-	const yr = d.getUTCFullYear();
-	const hh = String(d.getUTCHours()).padStart(2, "0");
-	const mm = String(d.getUTCMinutes()).padStart(2, "0");
-	const ss = String(d.getUTCSeconds()).padStart(2, "0");
+	const day = d.getDate();
+	const mon = MONTHS[d.getMonth()];
+	const yr = d.getFullYear();
+	const hh = String(d.getHours()).padStart(2, "0");
+	const mm = String(d.getMinutes()).padStart(2, "0");
+	const ss = String(d.getSeconds()).padStart(2, "0");
 	return `${day} ${mon} ${yr} ${hh}:${mm}:${ss}`;
 }
 

--- a/components/PageMonitoring/AuctionBidAction.tsx
+++ b/components/PageMonitoring/AuctionBidAction.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { PositionQuery, ChallengesQueryItem } from "@frankencoin/api";
-import { Address, formatUnits, parseEther } from "viem";
+import { Address, formatUnits, parseEther, parseUnits } from "viem";
 import TokenInput from "@components/Input/TokenInput";
 import AppButton from "@components/AppButton";
 import AppLink from "@components/AppLink";
@@ -16,6 +16,18 @@ import { ADDRESS, FrankencoinABI, MintingHubV1ABI, MintingHubV2ABI } from "@fran
 import { toast } from "react-toastify";
 import { track } from "@hooks";
 import { mainnet } from "viem/chains";
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+function fmtDate(d: Date): string {
+	const day = d.getUTCDate();
+	const mon = MONTHS[d.getUTCMonth()];
+	const yr = d.getUTCFullYear();
+	const hh = String(d.getUTCHours()).padStart(2, "0");
+	const mm = String(d.getUTCMinutes()).padStart(2, "0");
+	const ss = String(d.getUTCSeconds()).padStart(2, "0");
+	return `${day} ${mon} ${yr} ${hh}:${mm}:${ss}`;
+}
 
 interface Props {
 	position: PositionQuery;
@@ -83,6 +95,27 @@ export default function AuctionBidAction({ position, challenge, auctionPrice, on
 	}, [isInit, amount, auctionPrice, userBalance, challenge]);
 
 	const remainingSize = BigInt(challenge.size) - BigInt(challenge.filledSize);
+
+	const AVG_BLOCK_TIME_MS = 12_000; // Ethereum mainnet PoS
+	const priceDigits = 36 - position.collateralDecimals;
+	const marketPriceBigInt = marketPriceChf !== undefined ? parseUnits(marketPriceChf.toFixed(6), priceDigits) : undefined;
+	const endTimeMs = (parseInt(challenge.start.toString()) + parseInt(challenge.duration.toString())) * 1000;
+	const remainingMs = Math.max(0, endTimeMs - Date.now());
+
+	let marketReachedAt: string = "—";
+	let estimatedBlockStr: string = "—";
+	if (marketPriceBigInt !== undefined && auctionPrice > 0n) {
+		if (auctionPrice <= marketPriceBigInt) {
+			marketReachedAt = "Now";
+			estimatedBlockStr = data !== undefined ? `#${Number(data).toLocaleString()}` : "—";
+		} else if (remainingMs > 0) {
+			const msUntilMarket = Number((BigInt(remainingMs) * (auctionPrice - marketPriceBigInt)) / auctionPrice);
+			marketReachedAt = fmtDate(new Date(Date.now() + msUntilMarket));
+			if (data !== undefined) {
+				estimatedBlockStr = `#${Number(data) + Math.round(msUntilMarket / AVG_BLOCK_TIME_MS)}`;
+			}
+		}
+	}
 
 	// @dev: issues with amount conversion from string input. Reconvert to bigint.
 	const expectedZCHF = (BigInt(amount) * auctionPrice) / parseEther("1");
@@ -168,12 +201,28 @@ export default function AuctionBidAction({ position, challenge, auctionPrice, on
 
 			<div className="flex flex-col gap-1.5 text-sm">
 				<div className="flex justify-between items-center">
+					<span className="text-text-secondary">Initially</span>
+					<span className="text-text-primary font-medium">
+						{formatBigInt(challenge.size, position.collateralDecimals)} {position.collateralSymbol}
+					</span>
+				</div>
+				<div className="flex justify-between items-center">
 					<span className="text-text-secondary">Available</span>
 					<span className="text-text-primary font-medium">
 						{formatBigInt(remainingSize, position.collateralDecimals)} {position.collateralSymbol}
 					</span>
 				</div>
 				<div className="flex justify-between items-center">
+					<span className="text-text-secondary">Challenger</span>
+					<AppLink
+						className=""
+						label={shortenAddress(challenge.challenger)}
+						href={ContractUrl(challenge.challenger, WAGMI_CHAIN)}
+						external={true}
+					/>
+				</div>
+
+				<div className="flex justify-between items-center mt-2">
 					<span className="text-text-secondary">Price per unit</span>
 					<span className="text-text-primary font-medium">
 						{formatCurrency(formatUnits(auctionPrice, 36 - position.collateralDecimals), 2, 2)} ZCHF
@@ -186,21 +235,15 @@ export default function AuctionBidAction({ position, challenge, auctionPrice, on
 					</span>
 				</div>
 				<div className="flex justify-between items-center">
-					<span className="text-text-secondary">Initially available</span>
-					<span className="text-text-primary font-medium">
-						{formatBigInt(challenge.size, position.collateralDecimals)} {position.collateralSymbol}
-					</span>
+					<span className="text-text-secondary">Reaches market price</span>
+					<span className="text-text-primary font-medium">{marketReachedAt}</span>
 				</div>
 				<div className="flex justify-between items-center">
-					<span className="text-text-secondary">Challenger</span>
-					<AppLink
-						className=""
-						label={shortenAddress(challenge.challenger)}
-						href={ContractUrl(challenge.challenger, WAGMI_CHAIN)}
-						external={true}
-					/>
+					<span className="text-text-secondary">Est. block</span>
+					<span className="text-text-primary font-medium">{estimatedBlockStr}</span>
 				</div>
-				<div className="flex justify-between items-center">
+
+				<div className="flex justify-between items-center mt-2">
 					<span className="text-text-secondary">Your balance</span>
 					<span className="text-text-primary font-medium">{formatCurrency(formatUnits(userBalance, 18), 2, 2)} ZCHF</span>
 				</div>

--- a/components/PageMonitoring/ForceSellAction.tsx
+++ b/components/PageMonitoring/ForceSellAction.tsx
@@ -19,12 +19,12 @@ import { mainnet } from "viem/chains";
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 function fmtDate(d: Date): string {
-	const day = d.getUTCDate();
-	const mon = MONTHS[d.getUTCMonth()];
-	const yr = d.getUTCFullYear();
-	const hh = String(d.getUTCHours()).padStart(2, "0");
-	const mm = String(d.getUTCMinutes()).padStart(2, "0");
-	const ss = String(d.getUTCSeconds()).padStart(2, "0");
+	const day = d.getDate();
+	const mon = MONTHS[d.getMonth()];
+	const yr = d.getFullYear();
+	const hh = String(d.getHours()).padStart(2, "0");
+	const mm = String(d.getMinutes()).padStart(2, "0");
+	const ss = String(d.getSeconds()).padStart(2, "0");
 	return `${day} ${mon} ${yr} ${hh}:${mm}:${ss}`;
 }
 

--- a/components/PageMonitoring/ForceSellAction.tsx
+++ b/components/PageMonitoring/ForceSellAction.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { PositionQuery } from "@frankencoin/api";
-import { Address, formatUnits } from "viem";
+import { Address, formatUnits, parseUnits } from "viem";
 import TokenInput from "@components/Input/TokenInput";
 import AppButton from "@components/AppButton";
 import GuardSupportedChain from "@components/Guards/GuardSupportedChain";
 import { TxToast, renderErrorTxToast } from "@components/TxToast";
-import { formatBigInt, formatCurrency } from "@utils";
+import { formatBigInt, formatCurrency, normalizeAddress } from "@utils";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/redux.store";
 import { useConnection, useBlockNumber } from "wagmi";
 import { readContract, waitForTransactionReceipt, writeContract } from "wagmi/actions";
 import { WAGMI_CONFIG } from "../../app.config";
@@ -13,6 +15,18 @@ import { ADDRESS, FrankencoinABI, MintingHubV2ABI } from "@frankencoin/zchf";
 import { toast } from "react-toastify";
 import { track } from "@hooks";
 import { mainnet } from "viem/chains";
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+function fmtDate(d: Date): string {
+	const day = d.getUTCDate();
+	const mon = MONTHS[d.getUTCMonth()];
+	const yr = d.getUTCFullYear();
+	const hh = String(d.getUTCHours()).padStart(2, "0");
+	const mm = String(d.getUTCMinutes()).padStart(2, "0");
+	const ss = String(d.getUTCSeconds()).padStart(2, "0");
+	return `${day} ${mon} ${yr} ${hh}:${mm}:${ss}`;
+}
 
 interface Props {
 	position: PositionQuery;
@@ -31,6 +45,8 @@ export default function ForceSellAction({ position, auctionPrice, onBidSuccess }
 	const account = useConnection();
 	const chainId = mainnet.id;
 	const priceDigits = 36 - position.collateralDecimals;
+	const prices = useSelector((state: RootState) => state.prices.coingecko);
+	const marketPriceChf = prices[normalizeAddress(position.collateral)]?.price?.chf;
 
 	useEffect(() => {
 		const acc: Address | undefined = account.address;
@@ -55,6 +71,26 @@ export default function ForceSellAction({ position, auctionPrice, onBidSuccess }
 		setAmount(BigInt(position.collateralBalance));
 		setInit(true);
 	}, [isInit, position]);
+
+	const AVG_BLOCK_TIME_MS = 12_000;
+	const marketPriceBigInt = marketPriceChf !== undefined ? parseUnits(marketPriceChf.toFixed(6), priceDigits) : undefined;
+	const endTimeMs = (position.expiration + position.challengePeriod) * 1000;
+	const remainingMs = Math.max(0, endTimeMs - Date.now());
+
+	let marketReachedAt: string = "—";
+	let estimatedBlockStr: string = "—";
+	if (marketPriceBigInt !== undefined && auctionPrice > 0n) {
+		if (auctionPrice <= marketPriceBigInt) {
+			marketReachedAt = "Now";
+			estimatedBlockStr = data !== undefined ? `#${Number(data).toLocaleString()}` : "—";
+		} else if (remainingMs > 0) {
+			const msUntilMarket = Number((BigInt(remainingMs) * (auctionPrice - marketPriceBigInt)) / auctionPrice);
+			marketReachedAt = fmtDate(new Date(Date.now() + msUntilMarket));
+			if (data !== undefined) {
+				estimatedBlockStr = `#${Number(data) + Math.round(msUntilMarket / AVG_BLOCK_TIME_MS)}`;
+			}
+		}
+	}
 
 	const expectedZCHF = (bidAmount?: bigint) => {
 		if (!bidAmount) bidAmount = amount;
@@ -145,11 +181,27 @@ export default function ForceSellAction({ position, auctionPrice, onBidSuccess }
 						{formatBigInt(BigInt(position.collateralBalance), position.collateralDecimals)} {position.collateralSymbol}
 					</span>
 				</div>
-				<div className="flex justify-between items-center">
+				<div className="flex justify-between items-center mt-2">
 					<span className="text-text-secondary">Price per unit</span>
-					<span className="text-text-primary font-medium">{formatCurrency(formatUnits(auctionPrice, priceDigits), 2, 2)} ZCHF</span>
+					<span className="text-text-primary font-medium">
+						{formatCurrency(formatUnits(auctionPrice, priceDigits), 2, 2)} ZCHF
+					</span>
 				</div>
 				<div className="flex justify-between items-center">
+					<span className="text-text-secondary">Market price</span>
+					<span className="text-text-primary font-medium">
+						{marketPriceChf !== undefined ? `${formatCurrency(marketPriceChf, 2, 2)} ZCHF` : "—"}
+					</span>
+				</div>
+				<div className="flex justify-between items-center">
+					<span className="text-text-secondary">Reaches market price</span>
+					<span className="text-text-primary font-medium">{marketReachedAt}</span>
+				</div>
+				<div className="flex justify-between items-center">
+					<span className="text-text-secondary">Est. block</span>
+					<span className="text-text-primary font-medium">{estimatedBlockStr}</span>
+				</div>
+				<div className="flex justify-between items-center mt-2">
 					<span className="text-text-secondary">Your balance</span>
 					<span className="text-text-primary font-medium">{formatCurrency(formatUnits(userBalance, 18), 2, 2)} ZCHF</span>
 				</div>

--- a/components/WalletConnect.tsx
+++ b/components/WalletConnect.tsx
@@ -11,7 +11,10 @@ export default function WalletConnect() {
 			<div className="flex items-center gap-4 py-1">
 				<div
 					className="bg-card-body-secondary text-menu-back h-8 md:h-10 flex justify-center cursor-pointer items-center rounded-lg px-4 font-semibold hover:bg-button-hover"
-					onClick={() => { track("wallet_connect_clicked"); AppKit.open(); }}
+					onClick={() => {
+						track("wallet_connect_clicked");
+						AppKit.open();
+					}}
 				>
 					Connect Wallet
 				</div>

--- a/components/Web3Modal.tsx
+++ b/components/Web3Modal.tsx
@@ -21,8 +21,9 @@ const modal = createAppKit({
 	},
 	themeMode: "light",
 	themeVariables: {
-		"--w3m-color-mix": "#ffffff",
-		"--w3m-color-mix-strength": 40,
+		"--apkt-accent": "#000000",
+		"--apkt-color-mix": "#FFFFFF",
+		"--apkt-color-mix-strength": 40,
 	},
 });
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@fortawesome/free-brands-svg-icons": "^6.4.2",
 		"@fortawesome/free-solid-svg-icons": "^6.4.2",
 		"@fortawesome/react-fontawesome": "^0.2.0",
-		"@frankencoin/api": "^0.3.15",
+		"@frankencoin/api": "^0.3.16",
 		"@frankencoin/zchf": "^0.3.23",
 		"@reduxjs/toolkit": "^2.2.5",
 		"@reown/appkit": "^1.8.19",

--- a/pages/governance/bridges/[source]/[destination].tsx
+++ b/pages/governance/bridges/[source]/[destination].tsx
@@ -15,6 +15,7 @@ import AppToggle from "@components/AppToggle";
 import AppButton from "@components/AppButton";
 import ChainBySelect from "@components/Input/ChainBySelect";
 import GuardSupportedChain from "@components/Guards/GuardSupportedChain";
+import GuardQualifiedVoter from "@components/Guards/GuardQualifiedVoter";
 import NormalInput from "@components/Input/NormalInput";
 import { renderErrorTxToastDecode, TxToast } from "@components/TxToast";
 import { useDelegationHelpers } from "@hooks";
@@ -279,10 +280,10 @@ export default function CCIPRateLimitPage() {
 	return (
 		<>
 			<Head>
-				<title>Frankencoin - CCIP Rate Limit</title>
+				<title>Frankencoin - CCIP Rate Limits</title>
 			</Head>
 
-			<AppTitle title="CCIP Rate Limit">
+			<AppTitle title="CCIP Rate Limits">
 				<div className="text-text-secondary">
 					Configure the incoming and outgoing CCIP rate limits on{" "}
 					<span className="font-medium text-text-primary">{sourceChain.name}</span> for transfers to and from{" "}
@@ -295,7 +296,7 @@ export default function CCIPRateLimitPage() {
 						external={true}
 						className="inline"
 					/>
-					{" for details. Changes take effect immediately and require a qualified voter."}
+					{" for details. Changes take effect immediately — no timelock — but require a qualified FPS voter."}
 				</div>
 			</AppTitle>
 
@@ -366,7 +367,7 @@ export default function CCIPRateLimitPage() {
 			</AppCard>
 
 			<AppCard>
-				<div className="text-lg font-semibold">New rate limits</div>
+				<div className="text-lg font-semibold">Rate Limits</div>
 
 				<div className="grid grid-cols-1 md:grid-cols-2 gap-6">
 					<RateLimitForm
@@ -392,11 +393,13 @@ export default function CCIPRateLimitPage() {
 				</div>
 
 				<div className="mt-4 md:max-w-md md:ml-auto">
-					<GuardSupportedChain chainId={sourceChainId}>
-						<AppButton isLoading={isSubmitting} onClick={handleSubmit}>
-							Apply rate limits
-						</AppButton>
-					</GuardSupportedChain>
+					<GuardQualifiedVoter>
+						<GuardSupportedChain chainId={sourceChainId}>
+							<AppButton isLoading={isSubmitting} onClick={handleSubmit}>
+								Apply Rate Limits
+							</AppButton>
+						</GuardSupportedChain>
+					</GuardQualifiedVoter>
 				</div>
 			</AppCard>
 		</>

--- a/pages/governance/index.tsx
+++ b/pages/governance/index.tsx
@@ -75,9 +75,9 @@ export default function Governance() {
 
 			<AppTitle title="CCIP Admin Proposals">
 				<div className="text-text-secondary">
-					Changes to the CCIP bridge configuration — adding or removing chains, updating remote pool addresses, and adjusting rate
-					limits — require a governance proposal with a seven-day veto window. Any qualified FPS holder can deny a pending proposal
-					before its deadline.
+					Structural changes to the CCIP bridge — adding or removing chains, updating remote pool addresses, and transferring admin
+					— require a governance proposal with a seven-day veto window (21 days for admin transfer). Any qualified FPS holder can
+					deny a pending proposal before its deadline. Rate limit adjustments take effect immediately without a timelock.
 				</div>
 			</AppTitle>
 

--- a/pages/governance/index.tsx
+++ b/pages/governance/index.tsx
@@ -14,14 +14,17 @@ import { fetchLeadrate } from "../../redux/slices/savings.slice";
 import GovernanceMintersPropose from "@components/PageGovernance/GovernanceMintersPropose";
 import GovernanceDelegation from "@components/PageGovernance/GovernanceDelegation";
 import GovernanceCCIPBridgesTable from "@components/PageGovernance/GovernanceCCIPBridgesTable";
+import GovernanceCCIPAdminTable from "@components/PageGovernance/GovernanceCCIPAdminTable";
 import { useFPSAverageStats } from "@hooks";
 import { formatUnits } from "viem";
+import { fetchBridge } from "../../redux/slices/bridge.slice";
 
 export default function Governance() {
 	const stats = useFPSAverageStats();
 
 	useEffect(() => {
 		store.dispatch(fetchLeadrate());
+		store.dispatch(fetchBridge());
 	}, []);
 
 	return (
@@ -69,6 +72,16 @@ export default function Governance() {
 			<div className="flex justify-left">
 				<AppLink className="text-left" label="See all modules" href="/governance/modules" external={false} />
 			</div>
+
+			<AppTitle title="CCIP Admin Proposals">
+				<div className="text-text-secondary">
+					Changes to the CCIP bridge configuration — adding or removing chains, updating remote pool addresses, and adjusting rate
+					limits — require a governance proposal with a seven-day veto window. Any qualified FPS holder can deny a pending proposal
+					before its deadline.
+				</div>
+			</AppTitle>
+
+			<GovernanceCCIPAdminTable />
 
 			<AppTitle title="CCIP Bridges">
 				<div className="text-text-secondary">

--- a/redux/redux.store.ts
+++ b/redux/redux.store.ts
@@ -10,6 +10,7 @@ import { reducer as challengesReducer } from "./slices/challenges.slice";
 import { reducer as bidsReducer } from "./slices/bids.slice";
 import { reducer as savingsReducer } from "./slices/savings.slice";
 import { reducer as morphoReducer } from "./slices/morpho.slice";
+import { reducer as bridgeReducer } from "./slices/bridge.slice";
 
 // store with combined reducers
 export const store = configureStore({
@@ -22,6 +23,7 @@ export const store = configureStore({
 		bids: bidsReducer,
 		savings: savingsReducer,
 		morpho: morphoReducer,
+		bridge: bridgeReducer,
 	}),
 });
 

--- a/redux/slices/bridge.slice.ts
+++ b/redux/slices/bridge.slice.ts
@@ -1,0 +1,47 @@
+import { createSlice, Dispatch } from "@reduxjs/toolkit";
+import { FRANKENCOIN_API_CLIENT } from "../../app.config";
+import { showErrorToast } from "@utils";
+import { ApiCCIPChain, ApiCCIPProposal, BridgeState } from "./bridge.types";
+
+export const initialState: BridgeState = {
+	error: null,
+	loaded: false,
+	proposals: [],
+	chains: [],
+};
+
+export const slice = createSlice({
+	name: "bridge",
+	initialState,
+	reducers: {
+		hasError(state, action: { payload: string }) {
+			state.error = action.payload;
+		},
+		setLoaded(state, action: { payload: boolean }) {
+			state.loaded = action.payload;
+		},
+		setProposals(state, action: { payload: ApiCCIPProposal[] }) {
+			state.proposals = action.payload;
+		},
+		setChains(state, action: { payload: ApiCCIPChain[] }) {
+			state.chains = action.payload;
+		},
+	},
+});
+
+export const { reducer } = slice;
+
+export const fetchBridge = () => async (dispatch: Dispatch) => {
+	try {
+		const [proposalsRes, chainsRes] = await Promise.all([
+			FRANKENCOIN_API_CLIENT.get<{ list: ApiCCIPProposal[] }>("/bridge/proposals"),
+			FRANKENCOIN_API_CLIENT.get<{ list: ApiCCIPChain[] }>("/bridge/chains"),
+		]);
+		dispatch(slice.actions.setProposals(proposalsRes.data.list));
+		dispatch(slice.actions.setChains(chainsRes.data.list));
+		dispatch(slice.actions.setLoaded(true));
+	} catch (error) {
+		showErrorToast({ message: "Fetching Bridge", error });
+		dispatch(slice.actions.hasError(String(error)));
+	}
+};

--- a/redux/slices/bridge.types.ts
+++ b/redux/slices/bridge.types.ts
@@ -1,0 +1,36 @@
+export type ApiCCIPProposal = {
+	chainId: number;
+	hash: string;
+	proposer: string | null;
+	type: string | null;
+	deadline: number;
+	status: string;
+	details: string | null;
+	created: number;
+	txHash: string;
+	deniedAt: number | null;
+	deniedTxHash: string | null;
+	enactedAt: number | null;
+	enactedTxHash: string | null;
+};
+
+export type ApiCCIPChain = {
+	chainId: number;
+	remoteChainSelector: string;
+	active: boolean;
+	remoteTokenAddress: string | null;
+	outboundEnabled: boolean;
+	outboundCapacity: string;
+	outboundRate: string;
+	inboundEnabled: boolean;
+	inboundCapacity: string;
+	inboundRate: string;
+	rateLimitUpdatedAt: number | null;
+};
+
+export type BridgeState = {
+	error: string | null;
+	loaded: boolean;
+	proposals: ApiCCIPProposal[];
+	chains: ApiCCIPChain[];
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,10 +1107,10 @@
   dependencies:
     prop-types "^15.8.1"
 
-"@frankencoin/api@^0.3.15":
-  version "0.3.15"
-  resolved "https://registry.yarnpkg.com/@frankencoin/api/-/api-0.3.15.tgz#6c568a5912c18dfe5daaaab7801ef2e2ca8fe9e2"
-  integrity sha512-MCzp/uVHI0YCIqfEXGorao+Fwtk6Brpo/8vzouhPuNmxV8DI/sgvdWfaaqcGPnG4CK4LBksE3qQciUn7vPrIXA==
+"@frankencoin/api@^0.3.16":
+  version "0.3.16"
+  resolved "https://registry.yarnpkg.com/@frankencoin/api/-/api-0.3.16.tgz#efcb59296726cab2ed899d743c191b92638eab24"
+  integrity sha512-2IbqchkuhsLeVzeDIdmOWNOjiczjMMR7mEQvo6TdFYBuMOCV+tuKhsWZg9fHFCNQDyv784TToWyNZaJ9j9AfnA==
   dependencies:
     "@apollo/client" "^3.10.5"
     "@aws-sdk/client-s3" "^3.620.0"


### PR DESCRIPTION
## Summary
- New **CCIP Admin Proposals** section on the governance page: filterable, sortable table of CCIPAdmin proposals with Date (tx link), Proposer (address link), Chain, Type, and Status
- **Deny action** (`GovernanceCCIPAdminDenyAction`): calls `CCIPAdmin.deny(hash, helpers)` — shown during veto window
- **Enact action** (`GovernanceCCIPAdminEnactAction`): calls the correct apply function based on proposal type, reconstructing struct args from stored details JSON — shown after deadline
- New `GuardQualifiedVoter` guard using `useVotingPowers` (2% threshold); applied to all veto/deny actions across the app (minters, positions, CCIP deny)
- Leadrate actions extracted into self-contained `GovernanceLeadrateActionMint` / `GovernanceLeadrateActionSave` components with the guard
- CCIP rate limit page polished: `GuardQualifiedVoter` on submit, updated copy clarifying no-timelock behavior
- Redux `bridge` slice fetching `/bridge/proposals` and `/bridge/chains`

## Test plan
- [x] CCIP Admin Proposals table loads and filters by status (All / Pending / Enacted / Denied)
- [x] Date and Proposer columns link to correct block explorer
- [x] Pending proposals within deadline show Deny button; past deadline show Enact button
- [x] `GuardQualifiedVoter` shows "Insufficient Votes" for non-qualified wallets on all veto/deny actions
- [x] Leadrate propose cards still work after extraction
- [x] CCIP rate limit page shows vote guard before chain guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)