### PR TITLE
feat: add Pharos ratings to ratings page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ NEXT_PUBLIC_UMAMI_WEBSITE_ID=...
 XERBERUS_API_URL=https://api.xerberus.io/public/v1
 XERBERUS_API_KEY=
 XERBERUS_USER_EMAIL=
+
+# Pharos public API (server-side only — never expose to the client)
+PHAROS_API_URL=https://api.pharos.watch
+PHAROS_API_KEY=

--- a/hooks/usePharosRating.ts
+++ b/hooks/usePharosRating.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import type { PharosRating } from "../pages/api/ratings/pharos";
+
+type Result = {
+	data: PharosRating | null;
+	loading: boolean;
+	error: string | null;
+};
+
+export function usePharosRating(): Result {
+	const [data, setData] = useState<PharosRating | null>(null);
+	const [loading, setLoading] = useState<boolean>(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		const controller = new AbortController();
+		setLoading(true);
+		setError(null);
+
+		fetch("/api/ratings/pharos", { signal: controller.signal })
+			.then(async (res) => {
+				const body = await res.json();
+				if (!res.ok || body.status !== "success") {
+					throw new Error(body?.message ?? `Request failed (${res.status})`);
+				}
+				setData(body.data as PharosRating);
+			})
+			.catch((err) => {
+				if (err.name === "AbortError") return;
+				setError(err instanceof Error ? err.message : "Unknown error");
+				setData(null);
+			})
+			.finally(() => setLoading(false));
+
+		return () => controller.abort();
+	}, []);
+
+	return { data, loading, error };
+}

--- a/pages/api/ratings/list.ts
+++ b/pages/api/ratings/list.ts
@@ -15,6 +15,35 @@ type SuccessBody = { status: "success"; data: XerberusRating[] };
 type ErrorBody = { status: "error"; message: string };
 
 const ALLOWED_TYPES: XerberusEntityType[] = ["pool", "protocol", "organisation", "asset"];
+const UPSTREAM_TIMEOUT_MS = 8 * 1000;
+const ENABLE_DEV_MOCKS = process.env.NODE_ENV !== "production";
+
+const DEV_MOCK_RATINGS: XerberusRating[] = [
+	{
+		type: "protocol",
+		id: "frankencoin",
+		name: "Frankencoin",
+		score: 91,
+		platform: null,
+		address: null,
+	},
+	{
+		type: "organisation",
+		id: "frankencoin-dao",
+		name: "Frankencoin",
+		score: 87,
+		platform: null,
+		address: null,
+	},
+	{
+		type: "pool",
+		id: "frankencoin-savings-eth",
+		name: "Frankencoin Savings",
+		score: 83,
+		platform: "ethereum",
+		address: null,
+	},
+];
 
 const parseCsv = (raw: unknown): string[] | undefined => {
 	if (typeof raw !== "string" || raw.length === 0) return undefined;
@@ -23,6 +52,22 @@ const parseCsv = (raw: unknown): string[] | undefined => {
 		.map((s) => s.trim())
 		.filter(Boolean);
 	return parts.length > 0 ? parts : undefined;
+};
+
+const fetchWithTimeout = async (url: string, init: RequestInit, timeoutMs: number) => {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+	try {
+		return await fetch(url, { ...init, signal: controller.signal });
+	} catch (err) {
+		if (err instanceof Error && err.name === "AbortError") {
+			throw new Error(`Upstream request timed out after ${timeoutMs}ms`);
+		}
+		throw err;
+	} finally {
+		clearTimeout(timeout);
+	}
 };
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<SuccessBody | ErrorBody>) {
@@ -44,6 +89,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 	const userEmail = process.env.XERBERUS_USER_EMAIL;
 
 	if (!baseUrl || !apiKey || !userEmail) {
+		if (ENABLE_DEV_MOCKS) {
+			res.setHeader("X-Ratings-Mock", "xerberus");
+			return res.status(200).json({
+				status: "success",
+				data: types ? DEV_MOCK_RATINGS.filter((rating) => types.includes(rating.type)) : DEV_MOCK_RATINGS,
+			});
+		}
+
 		return res.status(500).json({
 			status: "error",
 			message: "Xerberus API is not configured (XERBERUS_API_URL, XERBERUS_API_KEY, XERBERUS_USER_EMAIL).",
@@ -56,14 +109,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 	const upstreamUrl = `${baseUrl.replace(/\/$/, "")}/registry/scores${params.toString() ? `?${params.toString()}` : ""}`;
 
 	try {
-		const upstream = await fetch(upstreamUrl, {
-			method: "GET",
-			headers: {
-				"x-api-key": apiKey,
-				"x-user-email": userEmail,
-				accept: "application/json",
+		const upstream = await fetchWithTimeout(
+			upstreamUrl,
+			{
+				method: "GET",
+				headers: {
+					"x-api-key": apiKey,
+					"x-user-email": userEmail,
+					accept: "application/json",
+				},
 			},
-		});
+			UPSTREAM_TIMEOUT_MS
+		);
 
 		const body = (await upstream.json().catch(() => null)) as SuccessBody | ErrorBody | null;
 

--- a/pages/api/ratings/pharos.ts
+++ b/pages/api/ratings/pharos.ts
@@ -1,0 +1,223 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type PharosDimensionKey = "pegStability" | "liquidity" | "resilience" | "decentralization" | "dependencyRisk";
+
+export type PharosDimensionRating = {
+	grade: string;
+	score: number | null;
+	detail: string;
+};
+
+export type PharosRating = {
+	id: "zchf-frankencoin";
+	name: string;
+	symbol: string;
+	overallGrade: string;
+	overallScore: number | null;
+	methodologyVersion: string | null;
+	updatedAt: number | null;
+	dimensions: Record<PharosDimensionKey, PharosDimensionRating>;
+};
+
+type SuccessBody = { status: "success"; data: PharosRating };
+type ErrorBody = { status: "error"; message: string };
+
+const PHAROS_STABLECOIN_ID = "zchf-frankencoin";
+const DEFAULT_PHAROS_API_URL = "https://api.pharos.watch";
+const PHAROS_CACHE_TTL_MS = 5 * 60 * 1000;
+const PHAROS_STALE_TTL_MS = PHAROS_CACHE_TTL_MS + 30 * 60 * 1000;
+const UPSTREAM_TIMEOUT_MS = 8 * 1000;
+const ENABLE_DEV_MOCKS = process.env.NODE_ENV !== "production";
+
+const DIMENSION_KEYS: PharosDimensionKey[] = ["pegStability", "liquidity", "resilience", "decentralization", "dependencyRisk"];
+
+let pharosCache: { fetchedAt: number; rating: PharosRating } | null = null;
+
+const DEV_MOCK_RATING: PharosRating = {
+	id: PHAROS_STABLECOIN_ID,
+	name: "Frankencoin",
+	symbol: "ZCHF",
+	overallGrade: "A-",
+	overallScore: 84,
+	methodologyVersion: "7.13",
+	updatedAt: 1771977600,
+	dimensions: {
+		pegStability: {
+			grade: "A",
+			score: 88,
+			detail: "Stable CHF peg behavior with limited recent deviation.",
+		},
+		liquidity: {
+			grade: "B+",
+			score: 79,
+			detail: "Usable exit liquidity across tracked venues and routes.",
+		},
+		resilience: {
+			grade: "A-",
+			score: 84,
+			detail: "Overcollateralized minting model with diversified accepted collateral.",
+		},
+		decentralization: {
+			grade: "A",
+			score: 87,
+			detail: "Governance and minting controls are materially on-chain.",
+		},
+		dependencyRisk: {
+			grade: "B",
+			score: 76,
+			detail: "Some collateral and venue exposure remains externally dependent.",
+		},
+	},
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+	return typeof value === "object" && value !== null;
+};
+
+const stringOrFallback = (value: unknown, fallback: string): string => {
+	return typeof value === "string" ? value : fallback;
+};
+
+const numberOrNull = (value: unknown): number | null => {
+	return typeof value === "number" && Number.isFinite(value) ? value : null;
+};
+
+const fetchWithTimeout = async (url: string, init: RequestInit, timeoutMs: number) => {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+	try {
+		return await fetch(url, { ...init, signal: controller.signal });
+	} catch (err) {
+		if (err instanceof Error && err.name === "AbortError") {
+			throw new Error(`Upstream request timed out after ${timeoutMs}ms`);
+		}
+		throw err;
+	} finally {
+		clearTimeout(timeout);
+	}
+};
+
+const setSuccessCacheHeaders = (res: NextApiResponse) => {
+	res.setHeader("Cache-Control", "public, s-maxage=300, max-age=60, stale-while-revalidate=1800");
+};
+
+const sendCachedRating = (
+	res: NextApiResponse<SuccessBody | ErrorBody>,
+	cache: { fetchedAt: number; rating: PharosRating },
+	stale: boolean
+) => {
+	setSuccessCacheHeaders(res);
+	res.setHeader("X-Pharos-Cache", stale ? "stale" : "hit");
+	if (stale) res.setHeader("Warning", '110 - "Response is stale"');
+	return res.status(200).json({ status: "success", data: cache.rating });
+};
+
+function parsePharosRating(body: unknown): PharosRating | null {
+	if (!isRecord(body) || !Array.isArray(body.cards)) return null;
+
+	const card = body.cards.find((candidate) => {
+		return isRecord(candidate) && candidate.id === PHAROS_STABLECOIN_ID;
+	});
+	if (!isRecord(card) || !isRecord(card.dimensions)) return null;
+
+	const rawDimensions = card.dimensions;
+	const dimensions = DIMENSION_KEYS.reduce((acc, key) => {
+		const rawDimension = rawDimensions[key];
+		if (!isRecord(rawDimension)) {
+			acc[key] = { grade: "NR", score: null, detail: "Dimension unavailable" };
+			return acc;
+		}
+
+		acc[key] = {
+			grade: stringOrFallback(rawDimension.grade, "NR"),
+			score: numberOrNull(rawDimension.score),
+			detail: stringOrFallback(rawDimension.detail, "Dimension unavailable"),
+		};
+		return acc;
+	}, {} as Record<PharosDimensionKey, PharosDimensionRating>);
+
+	const methodology = isRecord(body.methodology) ? body.methodology : null;
+
+	return {
+		id: PHAROS_STABLECOIN_ID,
+		name: stringOrFallback(card.name, "Frankencoin"),
+		symbol: stringOrFallback(card.symbol, "ZCHF"),
+		overallGrade: stringOrFallback(card.overallGrade, "NR"),
+		overallScore: numberOrNull(card.overallScore),
+		methodologyVersion: methodology ? stringOrFallback(methodology.version, "") || null : null,
+		updatedAt: numberOrNull(body.updatedAt),
+		dimensions,
+	};
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<SuccessBody | ErrorBody>) {
+	if (req.method !== "GET") {
+		res.setHeader("Allow", "GET");
+		return res.status(405).json({ status: "error", message: "Method Not Allowed" });
+	}
+
+	const apiKey = process.env.PHAROS_API_KEY;
+	if (!apiKey) {
+		if (ENABLE_DEV_MOCKS) {
+			setSuccessCacheHeaders(res);
+			res.setHeader("X-Ratings-Mock", "pharos");
+			return res.status(200).json({ status: "success", data: DEV_MOCK_RATING });
+		}
+
+		return res.status(500).json({
+			status: "error",
+			message: "Pharos API is not configured (PHAROS_API_KEY).",
+		});
+	}
+
+	const baseUrl = process.env.PHAROS_API_URL || DEFAULT_PHAROS_API_URL;
+	const upstreamUrl = `${baseUrl.replace(/\/$/, "")}/api/report-cards`;
+	const now = Date.now();
+	if (pharosCache && now - pharosCache.fetchedAt < PHAROS_CACHE_TTL_MS) {
+		return sendCachedRating(res, pharosCache, false);
+	}
+
+	try {
+		const upstream = await fetchWithTimeout(
+			upstreamUrl,
+			{
+				method: "GET",
+				headers: {
+					"X-API-Key": apiKey,
+					accept: "application/json",
+				},
+			},
+			UPSTREAM_TIMEOUT_MS
+		);
+
+		const body = (await upstream.json().catch(() => null)) as unknown;
+
+		if (!upstream.ok) {
+			const message = isRecord(body) && typeof body.error === "string" ? body.error : `Upstream request failed (${upstream.status})`;
+			if (pharosCache && now - pharosCache.fetchedAt < PHAROS_STALE_TTL_MS) {
+				return sendCachedRating(res, pharosCache, true);
+			}
+			return res.status(upstream.status || 502).json({ status: "error", message });
+		}
+
+		const rating = parsePharosRating(body);
+		if (!rating) {
+			if (pharosCache && now - pharosCache.fetchedAt < PHAROS_STALE_TTL_MS) {
+				return sendCachedRating(res, pharosCache, true);
+			}
+			return res.status(404).json({ status: "error", message: "Pharos rating for ZCHF was not found." });
+		}
+
+		pharosCache = { fetchedAt: Date.now(), rating };
+		setSuccessCacheHeaders(res);
+		res.setHeader("X-Pharos-Cache", "miss");
+		return res.status(200).json({ status: "success", data: rating });
+	} catch (err) {
+		const message = err instanceof Error ? err.message : "Unknown error contacting Pharos API";
+		if (pharosCache && now - pharosCache.fetchedAt < PHAROS_STALE_TTL_MS) {
+			return sendCachedRating(res, pharosCache, true);
+		}
+		return res.status(502).json({ status: "error", message });
+	}
+}

--- a/pages/ratings.tsx
+++ b/pages/ratings.tsx
@@ -3,23 +3,25 @@ import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import AppCard from "@components/AppCard";
 import { useRatings } from "../hooks/useRatings";
+import { usePharosRating } from "../hooks/usePharosRating";
+import type { PharosDimensionKey, PharosRating } from "./api/ratings/pharos";
 import type { XerberusEntityType } from "./api/ratings/list";
 
 const HOW_IT_WORKS = [
 	{
 		n: 1,
 		title: "Independent",
-		body: "Ratings are produced by Xerberus, an external open-source protocol, not by the Frankencoin DAO.",
+		body: "Ratings are produced by external analytics providers, not by the Frankencoin DAO.",
 	},
 	{
 		n: 2,
-		title: "Open Methodology",
-		body: "Every calculation is public and documented. No black-box algorithms, no hidden biases. Full intellectual transparency.",
+		title: "Public Methodology",
+		body: "Provider methodologies are documented so readers can check what each score measures.",
 	},
 	{
 		n: 3,
 		title: "Verifiable Sources",
-		body: "Because the math is open, the data must be too. Xerberus pulls directly from on-chain truth to feed its models. Trust, but verify.",
+		body: "Scores are backed by public on-chain, liquidity, and market data where possible.",
 	},
 ];
 
@@ -36,15 +38,40 @@ const RATING_CARDS: RatingCard[] = [
 	{ type: "pool", id: "frankencoin-savings-eth", name: "Frankencoin Savings", subtitle: "Ethereum Vault" },
 ];
 
+const PHAROS_DIMENSIONS: { key: PharosDimensionKey; label: string; shortLabel: string }[] = [
+	{ key: "pegStability", label: "Peg stability", shortLabel: "Peg" },
+	{ key: "liquidity", label: "Exit liquidity", shortLabel: "Exit" },
+	{ key: "resilience", label: "Resilience", shortLabel: "Resil." },
+	{ key: "decentralization", label: "Decentralization", shortLabel: "Decent." },
+	{ key: "dependencyRisk", label: "Dependency risk", shortLabel: "Dep." },
+];
+
+const RADAR_CENTER = 95;
+const RADAR_RADIUS = 58;
+const RADAR_LABEL_RADIUS = 77;
+const RADAR_VIEWBOX = "0 0 190 190";
+
 const xerberusReportUrl = (type: XerberusEntityType, id: string) => {
 	if (type === "pool") return `https://app.xerberus.io/pool/dendrogram/${id}`;
 	return "https://app.xerberus.io";
+};
+
+const formatUpdatedAt = (updatedAt: number | null) => {
+	if (!updatedAt) return null;
+	return new Intl.DateTimeFormat(undefined, {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+		timeZone: "UTC",
+	}).format(new Date(updatedAt * 1000));
 };
 
 export default function RatingsPage() {
 	const { data, loading, error } = useRatings({
 		types: Array.from(new Set(RATING_CARDS.map((c) => c.type))),
 	});
+	const pharos = usePharosRating();
+	const pharosUpdatedAt = formatUpdatedAt(pharos.data?.updatedAt ?? null);
 
 	const byKey = new Map(data.map((r) => [`${r.type}:${r.id}`, r]));
 
@@ -70,8 +97,19 @@ export default function RatingsPage() {
 						Xerberus
 						<FontAwesomeIcon icon={faArrowUpRightFromSquare} className="w-3 ml-0.5" />
 					</a>
-					, an open-source on-chain risk-rating protocol with no affiliation to Frankencoin. Each score below reflects a
-					transparent, automated analysis of public on-chain data.
+					, an open-source on-chain risk-rating protocol with no affiliation to Frankencoin. The ZCHF stablecoin also has an
+					independent Safety Score from{" "}
+					<a
+						href="https://pharos.watch/stablecoin/zchf-frankencoin/#report-card"
+						target="_blank"
+						rel="noreferrer"
+						className="inline-flex items-center gap-1 text-card-input-max hover:text-card-input-hover font-medium"
+					>
+						<PharosLogo className="h-4 w-4 rounded-full bg-text-primary p-0.5 align-text-bottom" />
+						Pharos
+						<FontAwesomeIcon icon={faArrowUpRightFromSquare} className="w-3 ml-0.5" />
+					</a>
+					.
 				</p>
 			</div>
 
@@ -120,6 +158,80 @@ export default function RatingsPage() {
 					);
 				})}
 			</div>
+
+			<div className="mt-4 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.6fr)] gap-4">
+				<AppCard className="p-5 flex flex-col gap-4">
+					<div className="flex items-center gap-3">
+						<picture>
+							<img src="/coin/zchf.png" alt="" className="h-10 w-10 rounded-full" />
+						</picture>
+						<div>
+							<div className="font-bold text-text-primary text-lg leading-tight">Frankencoin</div>
+							<div className="inline-flex items-center gap-1 text-text-secondary text-sm">
+								ZCHF Safety Score by <PharosLogo className="h-4 w-4 rounded-full bg-text-primary p-0.5" /> Pharos
+							</div>
+						</div>
+					</div>
+					<div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+						<PharosScoreDisplay rating={pharos.data} loading={pharos.loading} error={pharos.error} />
+						<span className="text-text-secondary text-sm">Pharos rating</span>
+					</div>
+					<div className="text-text-secondary text-sm leading-relaxed">
+						{pharos.data ? (
+							<>
+								Methodology {pharos.data.methodologyVersion ? `v${pharos.data.methodologyVersion}` : "version unavailable"}
+								{pharosUpdatedAt ? ` - Updated ${pharosUpdatedAt} UTC` : ""}
+							</>
+						) : (
+							"Peg, liquidity, resilience, decentralization, and dependency-risk analysis for ZCHF."
+						)}
+					</div>
+					<a
+						href="https://pharos.watch/stablecoin/zchf-frankencoin/#report-card"
+						target="_blank"
+						rel="noreferrer"
+						className="text-card-input-max hover:text-card-input-hover text-sm font-medium"
+					>
+						View full report on Pharos
+						<FontAwesomeIcon icon={faArrowUpRightFromSquare} className="w-3 ml-1" />
+					</a>
+				</AppCard>
+
+				<AppCard className="p-5 flex flex-col gap-4">
+					<div>
+						<div className="font-bold text-text-primary text-lg leading-tight">Pharos dimensions</div>
+						<div className="text-text-secondary text-sm">The Safety Score components published for ZCHF.</div>
+					</div>
+					<div className="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_220px] gap-8 lg:gap-12 items-center">
+						<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-1 gap-x-6 gap-y-3">
+							{PHAROS_DIMENSIONS.map(({ key, label }) => {
+								const dimension = pharos.data?.dimensions[key];
+								return (
+									<div
+										key={key}
+										className="flex min-h-[42px] items-center justify-between gap-4 border-b border-card-input-border pb-2"
+									>
+										<div className="min-w-0">
+											<div className="text-text-primary text-sm font-medium">{label}</div>
+											<div className="text-text-secondary text-xs truncate" title={dimension?.detail ?? undefined}>
+												{dimension?.detail ??
+													(pharos.loading ? "Loading" : pharos.error ? "Unavailable" : "No data")}
+											</div>
+										</div>
+										<div className="flex-none text-right">
+											<div className="text-card-input-max font-bold leading-tight">{dimension?.grade ?? "—"}</div>
+											<div className="text-text-secondary text-xs">
+												{dimension?.score == null ? "—" : `${dimension.score}/100`}
+											</div>
+										</div>
+									</div>
+								);
+							})}
+						</div>
+						<PharosRadarChart rating={pharos.data} loading={pharos.loading} />
+					</div>
+				</AppCard>
+			</div>
 		</>
 	);
 }
@@ -137,4 +249,89 @@ function ScoreDisplay({ score, loading, error }: { score: number | null; loading
 		);
 	}
 	return <span className="text-green-500 font-bold text-5xl leading-none">{score}%</span>;
+}
+
+function PharosLogo({ className }: { className: string }) {
+	return <img src="/partner/pharos.svg" alt="" className={className} />;
+}
+
+function PharosScoreDisplay({ rating, loading, error }: { rating: PharosRating | null; loading: boolean; error: string | null }) {
+	if (loading) {
+		return <span className="text-text-secondary font-bold text-5xl leading-none">—</span>;
+	}
+	if (!rating || rating.overallScore == null) {
+		return (
+			<span className="text-text-secondary font-bold text-5xl leading-none" title={error ?? "Score unavailable"}>
+				n/a
+			</span>
+		);
+	}
+	return (
+		<>
+			<span className="text-card-input-max font-bold text-5xl leading-none">{rating.overallGrade}</span>
+			<span className="text-text-primary font-bold text-2xl leading-none">{rating.overallScore}/100</span>
+		</>
+	);
+}
+
+function scoreToRadarPoint(index: number, score: number) {
+	const angle = -Math.PI / 2 + (index * 2 * Math.PI) / PHAROS_DIMENSIONS.length;
+	const radius = RADAR_RADIUS * (Math.max(0, Math.min(score, 100)) / 100);
+	return {
+		x: RADAR_CENTER + Math.cos(angle) * radius,
+		y: RADAR_CENTER + Math.sin(angle) * radius,
+	};
+}
+
+function radarPointsFor(scores: number[]) {
+	return scores
+		.map((score, index) => {
+			const point = scoreToRadarPoint(index, score);
+			return `${point.x.toFixed(1)},${point.y.toFixed(1)}`;
+		})
+		.join(" ");
+}
+
+function PharosRadarChart({ rating, loading }: { rating: PharosRating | null; loading: boolean }) {
+	const scores = PHAROS_DIMENSIONS.map(({ key }) => rating?.dimensions[key].score ?? 0);
+	const polygonPoints = radarPointsFor(scores);
+	const gridRings = [25, 50, 75, 100];
+
+	return (
+		<div className="mx-auto w-full max-w-[220px]" role="figure" aria-label="Pharos Safety Score radar chart for ZCHF">
+			<svg viewBox={RADAR_VIEWBOX} className="h-auto w-full" aria-hidden="true">
+				{gridRings.map((ring) => (
+					<polygon
+						key={ring}
+						points={radarPointsFor(PHAROS_DIMENSIONS.map(() => ring))}
+						fill="none"
+						stroke="#D7DCE7"
+						strokeWidth="1"
+					/>
+				))}
+				{PHAROS_DIMENSIONS.map(({ shortLabel }, index) => {
+					const axis = scoreToRadarPoint(index, 100);
+					const label = scoreToRadarPoint(index, (RADAR_LABEL_RADIUS / RADAR_RADIUS) * 100);
+					const anchor = label.x < RADAR_CENTER - 8 ? "end" : label.x > RADAR_CENTER + 8 ? "start" : "middle";
+					return (
+						<g key={shortLabel}>
+							<line x1={RADAR_CENTER} y1={RADAR_CENTER} x2={axis.x} y2={axis.y} stroke="#E5E8F0" strokeWidth="1" />
+							<text x={label.x} y={label.y + 4} textAnchor={anchor} className="fill-text-secondary text-[10px]">
+								{shortLabel}
+							</text>
+						</g>
+					);
+				})}
+				{!loading && rating ? (
+					<>
+						<polygon points={polygonPoints} fill="#3E96F4" fillOpacity="0.22" stroke="#0F80F0" strokeWidth="2.5" />
+						{scores.map((score, index) => {
+							const point = scoreToRadarPoint(index, score);
+							return <circle key={PHAROS_DIMENSIONS[index].key} cx={point.x} cy={point.y} r="2.5" fill="#0F80F0" />;
+						})}
+					</>
+				) : null}
+			</svg>
+		</div>
+	);
 }

--- a/public/partner/pharos.svg
+++ b/public/partner/pharos.svg
@@ -1,0 +1,37 @@
+<svg width="88" height="88" viewBox="0 0 88 88" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="pharosGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#E8DCC4" stop-opacity="0.45"/>
+      <stop offset="100%" stop-color="#E8DCC4" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="pharosTower" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#D4C8B0"/>
+      <stop offset="40%" stop-color="#E8DCC4"/>
+      <stop offset="100%" stop-color="#C8BBAA"/>
+    </linearGradient>
+    <filter id="pharosLanternGlow" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="3" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <circle cx="44" cy="16" r="16" fill="url(#pharosGlow)"/>
+  <line x1="44" y1="16" x2="44" y2="-4" stroke="#E8DCC4" stroke-width="2.5" opacity="0.55" stroke-linecap="round"/>
+  <line x1="44" y1="16" x2="22" y2="-2" stroke="#E8DCC4" stroke-width="2.5" opacity="0.4" stroke-linecap="round"/>
+  <line x1="44" y1="16" x2="66" y2="-2" stroke="#E8DCC4" stroke-width="2.5" opacity="0.4" stroke-linecap="round"/>
+  <line x1="44" y1="16" x2="4" y2="4" stroke="#E8DCC4" stroke-width="2" opacity="0.25" stroke-linecap="round"/>
+  <line x1="44" y1="16" x2="84" y2="4" stroke="#E8DCC4" stroke-width="2" opacity="0.25" stroke-linecap="round"/>
+  <line x1="44" y1="16" x2="-4" y2="14" stroke="#E8DCC4" stroke-width="1.5" opacity="0.15" stroke-linecap="round"/>
+  <line x1="44" y1="16" x2="92" y2="14" stroke="#E8DCC4" stroke-width="1.5" opacity="0.15" stroke-linecap="round"/>
+  <path d="M14,8 L74,8 L74,36 Q74,74 44,84 Q14,74 14,36 Z" fill="none" stroke="#E8DCC4" stroke-width="3" opacity="0.5" stroke-linejoin="round"/>
+  <circle cx="44" cy="16" r="5" fill="white" opacity="0.85" filter="url(#pharosLanternGlow)"/>
+  <path d="M39,22 C39,14 49,14 49,22 Z" fill="#E8DCC4" opacity="0.9"/>
+  <rect x="38.5" y="22" width="11" height="7" rx="1" fill="#F5F0E6" opacity="0.85"/>
+  <line x1="42" y1="22" x2="42" y2="29" stroke="#0a1628" stroke-width="0.8" opacity="0.3"/>
+  <line x1="46" y1="22" x2="46" y2="29" stroke="#0a1628" stroke-width="0.8" opacity="0.3"/>
+  <rect x="34" y="29" width="20" height="4" rx="1.5" fill="#E8DCC4" opacity="0.85"/>
+  <path d="M37,33 L51,33 L54,66 L34,66 Z" fill="url(#pharosTower)" opacity="0.8"/>
+  <line x1="36.2" y1="44" x2="52.2" y2="44" stroke="#0d1f3c" stroke-width="2" opacity="0.35"/>
+  <line x1="35.3" y1="55" x2="53.1" y2="55" stroke="#0d1f3c" stroke-width="2" opacity="0.35"/>
+  <rect x="30" y="66" width="28" height="5" rx="2.5" fill="#E8DCC4" opacity="0.7"/>
+  <rect x="26" y="71" width="36" height="5" rx="2.5" fill="#E8DCC4" opacity="0.45"/>
+</svg>


### PR DESCRIPTION
## Summary

- Adds Pharos Safety Score data alongside the Xerberus ratings page from #391.
- Adds a server-side Pharos proxy with API-key protection, response parsing, timeout handling, 5-minute cache headers, and stale fallback.
- Adds dev-only mock ratings when provider credentials are absent so reviewers can visually inspect `/ratings` locally.
- Documents `PHAROS_API_KEY` and optional `PHAROS_API_URL=https://api.pharos.watch` in `.env.example`.

## Review focus

- `pages/api/ratings/pharos.ts`: server-only Pharos integration, cache, stale fallback, timeout, parser
- `hooks/usePharosRating.ts`: client fetch hook
- `pages/ratings.tsx`: Pharos score card, dimensions list, radar chart, spacing
- `pages/api/ratings/list.ts`: timeout plus dev-only Xerberus mock fallback
- `.env.example`: Pharos env vars

## Notes

- Production behavior still requires real provider credentials; mocks only run when `NODE_ENV !== "production"`.
- No Pharos or Xerberus API keys are exposed to the client.
- This PR targets `feat/xerberus-ratings` in the Frankencoin repo so it can be reviewed as a focused follow-up to #391.

## Validation

- `npx prettier --check hooks/usePharosRating.ts pages/api/ratings/list.ts pages/api/ratings/pharos.ts pages/ratings.tsx`
- `npx tsc --noEmit`
- `git diff --cached --check` before commit
- `npx next build`
- Local visual check at `http://localhost:3000/ratings` with populated mock data

Visual QA screenshot was reviewed in the handoff thread before opening this PR.
