### PR TITLE
fix(mypositions): pass account address to PersonalizedNotifications

### DIFF
--- a/components/PageMypositions/PersonalizedNotifications.tsx
+++ b/components/PageMypositions/PersonalizedNotifications.tsx
@@ -2,8 +2,9 @@ import AppTitle from "@components/AppTitle";
 import AppLink from "@components/AppLink";
 import { TelegramLinkStatus } from "@components/PageMonitoring/TelegramLinkStatus";
 import { useConnection } from "wagmi";
+import { Address } from "viem";
 
-export default function PersonalizedNotifications() {
+export default function PersonalizedNotifications({ overwrite }: { overwrite?: Address }) {
 	const { address } = useConnection();
 
 	return (
@@ -18,7 +19,7 @@ export default function PersonalizedNotifications() {
 				</div>
 			</AppTitle>
 
-			<TelegramLinkStatus address={address} />
+			<TelegramLinkStatus address={overwrite ?? address} />
 		</>
 	);
 }

--- a/pages/mypositions/index.tsx
+++ b/pages/mypositions/index.tsx
@@ -110,19 +110,16 @@ export default function Positions() {
 			)}
 
 			{/* Section Positions */}
-			<AppTitle
-				title="Owned Positions"
-			>
+			<AppTitle title="Owned Positions">
 				<div className="text-text-secondary">
-					Open positions belonging to{" "}
-					<AppLink className="" label={shortenAddress(account)} href={accountUrl} external={true} />.
+					Open positions belonging to <AppLink className="" label={shortenAddress(account)} href={accountUrl} external={true} />.
 				</div>
 			</AppTitle>
 
 			<MypositionsTable />
 
 			{/* Section Personalized Notifications */}
-			<PersonalizedNotifications />
+			<PersonalizedNotifications overwrite={account} />
 
 			{/* Section Report */}
 			<AppTitle title="Yearly Accounts">


### PR DESCRIPTION
## Summary

- Adds optional `overwrite?: Address` prop to `PersonalizedNotifications` component
- Passes the page-level `account` address as `overwrite` so `TelegramLinkStatus` receives the correct address from context rather than re-reading it independently inside the component
- Minor formatting cleanup (whitespace/newline)

## Test plan

- [ ] Visit `/mypositions` with a connected wallet and verify the Telegram link status shows correctly
- [ ] Verify the Telegram notification section still renders without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)