### PR TITLE
Adapt analytics logs table to trimmed Ponder/API schema

### DIFF
--- a/components/PageLogs/LogsRow.tsx
+++ b/components/PageLogs/LogsRow.tsx
@@ -1,4 +1,4 @@
-import { formatUnits, Hash, parseEther } from "viem";
+import { formatUnits, Hash } from "viem";
 import TableRow from "../Table/TableRow";
 import { formatCurrency } from "../../utils/format";
 import { AnalyticsTransactionLog } from "@frankencoin/api";
@@ -17,9 +17,6 @@ export default function LogsRow({ headers, tab, log }: Props) {
 	const dateArr = new Date(parseInt(log.timestamp) * 1000).toLocaleString().split(", ");
 	const kindArr = log.kind.split(":");
 
-	const equityRatio = (BigInt(log.totalEquity) * parseEther("1")) / BigInt(log.totalSupply);
-	const savingsRatio = (BigInt(log.totalSavings) * parseEther("1")) / BigInt(log.totalSupply);
-
 	const openExplorer = (e: any) => {
 		e.preventDefault();
 		window.open(link, "_blank");
@@ -37,9 +34,8 @@ export default function LogsRow({ headers, tab, log }: Props) {
 			<div>{formatCurrency(formatUnits(log.amount, 18))}</div>
 
 			{/* totals */}
-			<div>{formatCurrency(formatUnits(log.totalSupply, 18 + 6))}M</div>
-			<div>{formatCurrency(formatUnits(equityRatio, 18 - 2))}%</div>
-			<div>{formatCurrency(formatUnits(savingsRatio, 18 - 2))}%</div>
+			<div>{formatCurrency(formatUnits(log.totalEquity, 18 + 6))}M</div>
+			<div>{formatCurrency(formatUnits(log.totalSavings, 18 + 6))}M</div>
 
 			{/* FPS */}
 			<div>{formatCurrency(formatUnits(log.fpsPrice, 18))}</div>
@@ -47,7 +43,6 @@ export default function LogsRow({ headers, tab, log }: Props) {
 
 			{/* analytics */}
 			<div>{formatCurrency(formatUnits(log.realizedNetEarnings, 18 + 6))}M</div>
-			<div>{formatCurrency(formatUnits(log.annualNetEarnings, 18 + 6))}M</div>
 			<div>{formatCurrency(formatUnits(log.earningsPerFPS, 18))}</div>
 		</TableRow>
 	);

--- a/components/PageLogs/LogsTable.tsx
+++ b/components/PageLogs/LogsTable.tsx
@@ -20,13 +20,11 @@ export default function LogsTable() {
 		"Date",
 		"Tx Kind",
 		"Tx Amount",
-		"ZCHF Supply",
-		"In Equity",
-		"In Savings",
+		"Equity",
+		"Savings",
 		"FPS Price",
 		"FPS Supply",
 		"Earnings 365days",
-		"Earnings Annual",
 		"Earn. FPS (accum.)",
 	];
 	const [tab, setTab] = useState<string>(headers[0]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "frankencoin-dapp",
-	"version": "0.2.20",
+	"version": "0.2.21",
 	"private": false,
 	"license": "MIT",
 	"scripts": {
@@ -25,7 +25,7 @@
 		"@fortawesome/free-brands-svg-icons": "^6.4.2",
 		"@fortawesome/free-solid-svg-icons": "^6.4.2",
 		"@fortawesome/react-fontawesome": "^0.2.0",
-		"@frankencoin/api": "^0.3.18",
+		"@frankencoin/api": "^0.3.19",
 		"@frankencoin/zchf": "^0.3.25",
 		"@reduxjs/toolkit": "^2.2.5",
 		"@reown/appkit": "^1.8.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,10 +1107,10 @@
   dependencies:
     prop-types "^15.8.1"
 
-"@frankencoin/api@^0.3.18":
-  version "0.3.18"
-  resolved "https://registry.yarnpkg.com/@frankencoin/api/-/api-0.3.18.tgz#fb9c50264237214e467225ac0417757e52adf8a3"
-  integrity sha512-BDHgMk42VinA3ojRiJX9lXU+IzPnygUlf/UIBjg64Hfz8mkHEliijmVVAGHHVAUILdh8ani6DHXvJ8Ybc6XJ8g==
+"@frankencoin/api@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@frankencoin/api/-/api-0.3.19.tgz#c4df5d7a0086b1b200f3f1b071f3d60b62bfd71f"
+  integrity sha512-PV6T9RzJz+s2D4kld1SDAuE1ry+agKy2ocBxRc0yAJzjn9lccDb3Ws/wzG6mkNJPdH3ZaHUamNTsG/CTa0+b1g==
   dependencies:
     "@apollo/client" "^3.10.5"
     "@aws-sdk/client-s3" "^3.620.0"


### PR DESCRIPTION
## Summary
- Bumps `@frankencoin/api` to `0.3.19`, which trims `AnalyticTransactionLog`/`AnalyticDailyLog` to only the fields actually consumed downstream and drops `totalSupply` entirely (was mainnet-only, no longer tracked at that granularity — see [Frankencoin-ZCHF/ponder#63](https://github.com/Frankencoin-ZCHF/ponder/issues/63) for the investigation that led to trimming the source data)
- Removes the "ZCHF Supply" and "Earnings Annual" columns from `/monitoring/logs` (fields no longer exist)
- Shows "Equity"/"Savings" as absolute ZCHF amounts instead of a percentage of `totalSupply`, since that ratio can no longer be computed

## Test plan
- [x] `npx tsc --noEmit` passes clean against the real published `@frankencoin/api@0.3.19` types
- [x] `yarn build` completes static generation for all 27 pages including `/monitoring/logs`, `/equity`, `/report`
- [ ] Visually spot-check `/monitoring/logs` renders correctly with the new columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)