### PR TITLE
Fix chained delegation not shown in voting power list

### DIFF
--- a/components/PageGovernance/GovernanceDelegation.tsx
+++ b/components/PageGovernance/GovernanceDelegation.tsx
@@ -8,6 +8,8 @@ import { useDelegationQuery, useDelegationHelpers, useVotesSynced } from "@hooks
 import { formatCurrency, normalizeAddress, shortenAddress } from "@utils";
 import AddressInput from "@components/Input/AddressInput";
 import ChainSyncedVotes from "@components/Input/ChainSyncedVotes";
+import AppLink from "@components/AppLink";
+import { ContractUrl } from "@utils";
 import { WAGMI_CHAINS } from "../../app.config";
 import GovernanceDelegationAction from "./GovernanceDelegationAction";
 import GovernanceSyncAction from "./GovernanceSyncAction";
@@ -53,9 +55,9 @@ export default function GovernanceDelegation() {
 
 	const { data: readData } = useReadContracts({ contracts: contractReads as any });
 
-	const totalVotes: bigint = readData ? ((readData[voters.length + 1]?.result as bigint) ?? 0n) : 0n;
-	const totalDelegated: bigint = readData ? ((readData[voters.length]?.result as bigint) ?? 0n) : 0n;
-	const votingPowers: bigint[] = voters.map((_, i) => (readData ? ((readData[i]?.result as bigint) ?? 0n) : 0n));
+	const totalVotes: bigint = readData ? (readData[voters.length + 1]?.result as bigint) ?? 0n : 0n;
+	const totalDelegated: bigint = readData ? (readData[voters.length]?.result as bigint) ?? 0n : 0n;
+	const votingPowers: bigint[] = voters.map((_, i) => (readData ? (readData[i]?.result as bigint) ?? 0n : 0n));
 
 	const myVotes = votingPowers[0] ?? 0n;
 	const delegatorVotes: { address: Address; votes: bigint }[] = helpers
@@ -85,8 +87,7 @@ export default function GovernanceDelegation() {
 
 	// synced votes on the selected target chain
 	const { syncedVotes, totalVotes: syncTotalVotes } = useVotesSynced(myAddress, helpers, syncChainId);
-	const syncedPct =
-		syncTotalVotes > 0n ? `${formatCurrency((Number(syncedVotes) / Number(syncTotalVotes)) * 100)}%` : "—";
+	const syncedPct = syncTotalVotes > 0n ? `${formatCurrency((Number(syncedVotes) / Number(syncTotalVotes)) * 100)}%` : "—";
 
 	return (
 		<div className="grid grid-cols-1 md:grid-cols-2 gap-2">
@@ -124,7 +125,15 @@ export default function GovernanceDelegation() {
 						{/* Supporter rows */}
 						{delegatorVotes.map(({ address: addr, votes: vp }) => (
 							<div key={addr} className="grid grid-cols-2 items-center py-1 border-b border-card-input-border">
-								<div className="text-sm text-text-primary truncate">{shortenAddress(addr)}</div>
+								<div className="text-sm text-text-primary truncate">
+									<AppLink
+										label={shortenAddress(addr)}
+										href={ContractUrl(addr)}
+										external={true}
+										copyValue={addr}
+										className=""
+									/>
+								</div>
 								<div className="text-right text-sm text-text-primary">{formatPct(vp)}</div>
 							</div>
 						))}
@@ -182,11 +191,7 @@ export default function GovernanceDelegation() {
 						pct={syncedPct}
 					/>
 
-					<GovernanceSyncAction
-						targetChainId={syncChainId}
-						voters={voters}
-						disabled={!isConnected || voters.length === 0}
-					/>
+					<GovernanceSyncAction targetChainId={syncChainId} voters={voters} disabled={!isConnected || voters.length === 0} />
 				</div>
 			</AppCard>
 		</div>

--- a/hooks/useDelegationHelpers.ts
+++ b/hooks/useDelegationHelpers.ts
@@ -23,7 +23,7 @@ export const collectHelpers = (address: Address, delegatees: DelegateeMap): Addr
 		}
 	};
 	collect(address);
-	return helpers;
+	return helpers.sort();
 };
 
 export const computeSupporterCount = (address: Address, delegatees: DelegateeMap): number =>

--- a/hooks/useVotingPowers.ts
+++ b/hooks/useVotingPowers.ts
@@ -1,6 +1,7 @@
 import { useConnection, useReadContracts } from "wagmi";
 import { useFPSHolders } from "./useFPSHolders";
 import { useDelegationQuery } from "./useDelegationQuery";
+import { collectHelpers } from "./useDelegationHelpers";
 import { decodeBigIntCall, normalizeAddress } from "../utils/format";
 import { ADDRESS, EquityABI } from "@frankencoin/zchf";
 import { Address } from "viem";
@@ -77,7 +78,7 @@ export const useVotingPowers = () => {
 	if (data) {
 		for (let i = 0; i < n; i++) {
 			const addr = allAddresses[i];
-			const supporters: Address[] = delegatees[addr] ?? [];
+			const supporters: Address[] = collectHelpers(addr, delegatees);
 			const supportedVotingPower = supporters.reduce((sum, s) => sum + (votePowerMap.get(normalizeAddress(s)) ?? 0n), 0n);
 
 			const votingPower = votePowerMap.get(addr) ?? 0n;


### PR DESCRIPTION
## Summary
- `hooks/useVotingPowers.ts` computed each address's supporter list with a flat one-hop map lookup, so chained delegations (A -> B -> C) only counted direct delegators (B) and dropped indirect ones (A) from both the display count and `supportedVotingPower`. Now reuses the existing recursive `collectHelpers` traversal from `hooks/useDelegationHelpers.ts` to include the full transitive closure of delegators.
- `collectHelpers` now sorts its returned `helpers` array (`hooks/useDelegationHelpers.ts`). The `votesDelegated` contract call (and several other governance write calls) require a strictly ascending, deduplicated `helpers` array or the transaction reverts — the DFS traversal order was not guaranteed to satisfy that.
- `components/PageGovernance/GovernanceDelegation.tsx`: supporter addresses in the "Voting Support" card are now rendered via `AppLink` (external link + copy-to-clipboard) instead of plain text, matching the pattern already used elsewhere in governance.

Closes #405

## Test plan
- [x] `yarn tsc --noEmit` passes
- [ ] Manually verify on a wallet with a chained delegation (A -> B -> C) that C's Governance page shows both A and B as supporters, with correct combined voting power
- [ ] Manually verify voting/proposal actions that pass `helpers` (delegate, sync votes, proposals) still succeed on-chain for a multi-supporter chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)