### PR TITLE
Add geo-blocking for jurisdictionally restricted collateral

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,22 +1,59 @@
 import { NextRequest, NextResponse } from "next/server";
+import { createPublicClient, http, isAddress } from "viem";
+import { mainnet } from "viem/chains";
 import { isCollateralBlockedForCountry } from "./utils/geoBlocking";
 
-// Only runs on pages that are keyed by a collateral address in the URL.
+// Only runs on pages that are keyed by a position address in the URL.
 export const config = {
 	matcher: ["/mint/:path*", "/monitoring/:path*", "/mypositions/:path*"],
 };
 
-export function middleware(request: NextRequest) {
+// Mirrors app.config.ts's mainnet transport. Positions in this app are mainnet-only
+// (all three matched pages hardcode chainId = mainnet.id), so no chain lookup needed.
+const RPC_URL = `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_RPC_KEY || "dhaKbi2HDlKYW1JaSHm1i_hGkE2gnA5t"}`;
+
+// Minimal fragment instead of importing the full Position ABI from @frankencoin/zchf -
+// the function selector for collateral() is identical across V1/V2 positions.
+const COLLATERAL_ABI = [
+	{
+		inputs: [],
+		name: "collateral",
+		outputs: [{ type: "address" }],
+		stateMutability: "view",
+		type: "function",
+	},
+] as const;
+
+const publicClient = createPublicClient({ chain: mainnet, transport: http(RPC_URL) });
+
+async function resolveCollateralForPosition(positionAddress: `0x${string}`): Promise<string | undefined> {
+	try {
+		return await publicClient.readContract({
+			address: positionAddress,
+			abi: COLLATERAL_ABI,
+			functionName: "collateral",
+		});
+	} catch {
+		return undefined;
+	}
+}
+
+export async function middleware(request: NextRequest) {
 	const [, address] = request.nextUrl.pathname.split("/").filter(Boolean);
-	if (!address) return NextResponse.next();
+	if (!address || !isAddress(address)) return NextResponse.next();
+
+	const collateral = await resolveCollateralForPosition(address);
+	if (!collateral) return NextResponse.next();
 
 	// Set by Cloudflare when the "IP Geolocation" feature is enabled for the zone.
 	const country = request.headers.get("cf-ipcountry");
-	const blocked = isCollateralBlockedForCountry(address, country);
-	console.log(`[geoBlocking] path=${request.nextUrl.pathname} address=${address} country=${country} blocked=${blocked}`);
+	const blocked = isCollateralBlockedForCountry(collateral, country);
+	console.log(
+		`[geoBlocking] path=${request.nextUrl.pathname} position=${address} collateral=${collateral} country=${country} blocked=${blocked}`
+	);
 
 	if (blocked) {
-		return new NextResponse("This asset is not available in your region.", { status: 451 });
+		return NextResponse.rewrite(new URL("/restricted", request.url));
 	}
 
 	return NextResponse.next();

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isCollateralBlockedForCountry } from "./utils/geoBlocking";
+
+// Only runs on pages that are keyed by a collateral address in the URL.
+export const config = {
+	matcher: ["/mint/:path*", "/monitoring/:path*", "/mypositions/:path*"],
+};
+
+export function middleware(request: NextRequest) {
+	const [, address] = request.nextUrl.pathname.split("/").filter(Boolean);
+	if (!address) return NextResponse.next();
+
+	// Set by Cloudflare when the "IP Geolocation" feature is enabled for the zone.
+	const country = request.headers.get("cf-ipcountry");
+	const blocked = isCollateralBlockedForCountry(address, country);
+	console.log(`[geoBlocking] path=${request.nextUrl.pathname} address=${address} country=${country} blocked=${blocked}`);
+
+	if (blocked) {
+		return new NextResponse("This asset is not available in your region.", { status: 451 });
+	}
+
+	return NextResponse.next();
+}

--- a/pages/restricted.tsx
+++ b/pages/restricted.tsx
@@ -1,0 +1,31 @@
+import Head from "next/head";
+import { SOCIAL } from "@utils";
+import AppLink from "@components/AppLink";
+
+export default function Restricted() {
+	return (
+		<>
+			<Head>
+				<title>Frankencoin - Restricted</title>
+			</Head>
+
+			<div className="flex flex-col items-center justify-center w-full text-center" style={{ height: "60vh" }}>
+				<h1 className="text-right text-4xl font-bold">
+					<picture>
+						<img src="/assets/logoSquare.svg" alt="logo" className="h-20" />
+					</picture>
+				</h1>
+				<h1 className="text-4xl font-bold mt-10">Not available in your region</h1>
+				<p className="mt-4 max-w-lg text-text-secondary">
+					The resource you are trying to request is not available in your region due to jurisdictional restrictions.
+				</p>
+				<AppLink
+					className="mt-[4rem] -mb-[4rem]"
+					label="Questions? Ping us on Github"
+					href={SOCIAL.Github_dapp_new_issue}
+					external={true}
+				/>
+			</div>
+		</>
+	);
+}

--- a/utils/geoBlocking.ts
+++ b/utils/geoBlocking.ts
@@ -8,9 +8,9 @@ import { normalizeAddress } from "./format";
 // into the edge middleware.
 //
 // SPYon list is Ondo's "Jurisdiction-Based Prohibitions" (Ondo GM tokens). Country-level
-// only, since cf-ipcountry can't resolve sub-national regions - the Crimea/DNR/LNR/Kherson/
-// Zaporizhzhia/Sevastopol entries on that list have no ISO country code and aren't covered
-// here; they'd need separate enforcement (e.g. blocking wallet addresses on an OFAC list).
+// only, since cf-ipcountry can't resolve sub-national regions - the source list's
+// Crimea/DNR/LNR/Kherson/Zaporizhzhia/Sevastopol entries are approximated here by
+// blocking Ukraine (UA) entirely, rather than left uncovered.
 const COLLATERAL_GEO_BLOCKS: Record<string, string[]> = {
 	"0xfedc5f4a6c38211c1338aa411018dfaf26612c08": [
 		"AF", // Afghanistan
@@ -26,6 +26,7 @@ const COLLATERAL_GEO_BLOCKS: Record<string, string[]> = {
 		"SS", // South Sudan
 		"SD", // Sudan
 		"SY", // Syria
+		"UA", // Ukraine (approximates Crimea / DNR / LNR / Kherson / Zaporizhzhia / Sevastopol)
 		"US", // United States (incl. all territories & federal districts)
 	], // SPYon - SPDR S&P 500 ETF (Ondo Tokenized)
 };

--- a/utils/geoBlocking.ts
+++ b/utils/geoBlocking.ts
@@ -2,13 +2,16 @@
 // that must be blocked from accessing pages for that collateral, per the
 // jurisdictional restrictions of the underlying tokenized asset.
 // Kept dependency-free (no viem/format imports) so it stays safe to bundle
+
+import { normalizeAddress } from "./format";
+
 // into the edge middleware.
 const COLLATERAL_GEO_BLOCKS: Record<string, string[]> = {
 	"0xfedc5f4a6c38211c1338aa411018dfaf26612c08": ["US"], // SPYon - SPDR S&P 500 ETF (Ondo Tokenized)
 };
 
 export function getBlockedCountriesForCollateral(address: string): string[] {
-	return COLLATERAL_GEO_BLOCKS[address.toLowerCase()] ?? [];
+	return COLLATERAL_GEO_BLOCKS[normalizeAddress(address)] ?? [];
 }
 
 export function isCollateralBlockedForCountry(address: string, countryCode: string | null | undefined): boolean {

--- a/utils/geoBlocking.ts
+++ b/utils/geoBlocking.ts
@@ -1,0 +1,17 @@
+// Maps lowercase collateral addresses to the ISO 3166-1 alpha-2 country codes
+// that must be blocked from accessing pages for that collateral, per the
+// jurisdictional restrictions of the underlying tokenized asset.
+// Kept dependency-free (no viem/format imports) so it stays safe to bundle
+// into the edge middleware.
+const COLLATERAL_GEO_BLOCKS: Record<string, string[]> = {
+	"0xfedc5f4a6c38211c1338aa411018dfaf26612c08": ["US"], // SPYon - SPDR S&P 500 ETF (Ondo Tokenized)
+};
+
+export function getBlockedCountriesForCollateral(address: string): string[] {
+	return COLLATERAL_GEO_BLOCKS[address.toLowerCase()] ?? [];
+}
+
+export function isCollateralBlockedForCountry(address: string, countryCode: string | null | undefined): boolean {
+	if (!countryCode) return false;
+	return getBlockedCountriesForCollateral(address).includes(countryCode.toUpperCase());
+}

--- a/utils/geoBlocking.ts
+++ b/utils/geoBlocking.ts
@@ -6,8 +6,28 @@
 import { normalizeAddress } from "./format";
 
 // into the edge middleware.
+//
+// SPYon list is Ondo's "Jurisdiction-Based Prohibitions" (Ondo GM tokens). Country-level
+// only, since cf-ipcountry can't resolve sub-national regions - the Crimea/DNR/LNR/Kherson/
+// Zaporizhzhia/Sevastopol entries on that list have no ISO country code and aren't covered
+// here; they'd need separate enforcement (e.g. blocking wallet addresses on an OFAC list).
 const COLLATERAL_GEO_BLOCKS: Record<string, string[]> = {
-	"0xfedc5f4a6c38211c1338aa411018dfaf26612c08": ["US"], // SPYon - SPDR S&P 500 ETF (Ondo Tokenized)
+	"0xfedc5f4a6c38211c1338aa411018dfaf26612c08": [
+		"AF", // Afghanistan
+		"BY", // Belarus
+		"CA", // Canada
+		"CU", // Cuba
+		"KP", // Democratic People's Republic of Korea
+		"IR", // Iran
+		"LY", // Libya
+		"MM", // Myanmar
+		"RU", // Russia
+		"SO", // Somalia
+		"SS", // South Sudan
+		"SD", // Sudan
+		"SY", // Syria
+		"US", // United States (incl. all territories & federal districts)
+	], // SPYon - SPDR S&P 500 ETF (Ondo Tokenized)
 };
 
 export function getBlockedCountriesForCollateral(address: string): string[] {

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -2,6 +2,7 @@ export * from "./collateralCategories";
 export * from "./constant";
 export * from "./format-array";
 export * from "./format";
+export * from "./geoBlocking";
 export * from "./math";
 export * from "./helpers";
 export * from "./uniswapV3Math";


### PR DESCRIPTION
## Summary
- Add `middleware.ts` to geo-block `/mint`, `/monitoring`, and `/mypositions` pages per collateral, using Cloudflare's `CF-IPCountry` header
- Since the URL param on those pages is a position address (not a collateral address), the middleware resolves the collateral via an on-chain `collateral()` read against the position contract (mainnet)
- Add `utils/geoBlocking.ts`, a config mapping collateral addresses to blocked ISO country codes; seeded with SPYon (Ondo Tokenized SPDR S&P 500 ETF) per Ondo's Jurisdiction-Based Prohibitions list (Crimea/DNR/LNR/Kherson/Zaporizhzhia/Sevastopol approximated by blocking Ukraine, since Cloudflare's geo-IP only resolves at the country level)
- Add `pages/restricted.tsx`, a notice page (styled after the existing 404 page) that blocked requests are rewritten to

## Test plan
- [ ] Enable "IP Geolocation" for the zone in Cloudflare (Network settings) so `CF-IPCountry` is actually sent
- [ ] Deploy this branch to a dev environment and visit a SPYon position's `/mint`, `/monitoring`, and `/mypositions` page from a blocked country (e.g. via VPN) - confirm it renders `/restricted`
- [ ] Confirm the same pages load normally from a non-blocked country
- [ ] Check server logs for the `[geoBlocking]` debug line (temporary, for testing) and remove it before merging if no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)