### PR TITLE
fix(transfer): guard against null entries in transfer reference list

### DIFF
--- a/components/PageTransfer/TransferListTable.tsx
+++ b/components/PageTransfer/TransferListTable.tsx
@@ -171,7 +171,11 @@ type SortFunctionParams = {
 
 function sortFunction(params: SortFunctionParams): TransferReferenceQuery[] {
 	const { list, headers, tab, reverse } = params;
-	let sortingList = [...list]; // make it writeable
+	// Guard against null/malformed entries coming from the API; any of the
+	// comparators below (b.created, a.from, a.to, a.reference, b.amount) will
+	// throw on a null element and crash the whole page via the Next.js error
+	// boundary ("a client-side exception has occurred").
+	let sortingList = list.filter((i): i is TransferReferenceQuery => i != null); // writeable + null-safe
 
 	if (tab === headers[0]) {
 		// Date


### PR DESCRIPTION
## Problem

`/transfer` crashes for everyone with **"Application error: a client-side exception has occurred"**:

```
TypeError: null is not an object (evaluating 'e.created')   // Safari
TypeError: Cannot read properties of null (reading 'created') // Chrome
    at Array.sort
    at sortFunction (components/PageTransfer/TransferListTable.tsx)
```

## Root cause

`GET https://api.frankencoin.com/transfer/reference/list` returns `{ num: 1003, list: [...] }` where several entries are malformed:

- `list[1]` and `list[1002]` are `null`
- `list[0]` is a placeholder `{"__typename":"TransferReference","count":"TransferReference"}` (no `created`)

Every branch of `sortFunction` dereferences the element (`b.created`, `a.from.localeCompare`, `a.to`, `a.reference`, `b.amount`), so a single `null` throws and takes the whole page down via the Next.js error boundary.

## Fix

Filter null/undefined entries once, before sorting — protects all sort modes plus the downstream id-mapping (`l.chainId`, `l.count`) and row render.

```diff
-	let sortingList = [...list]; // make it writeable
+	let sortingList = list.filter((i): i is TransferReferenceQuery => i != null);
```

## Verification

- `yarn install --frozen-lockfile` — clean (patch-package applied)
- `yarn build` — production build passes, `/transfer` compiles
- `prettier --check` — clean

## Follow-up (backend, separate)

This PR is defense-in-depth. The **real cause is the API/indexer emitting null/placeholder rows** in `/transfer/reference/list`. The API should filter null/incomplete entries (require `created`, `txHash`) and ensure `num` reflects only valid entries. The `list[0]` placeholder (`count: "TransferReference"`) looks like GraphQL response metadata being mis-flattened into the array.
