### PR TITLE
fix(transfer): drop incomplete rows and guard URL builders against undefined

### DIFF
--- a/components/PageTransfer/TransferListTable.tsx
+++ b/components/PageTransfer/TransferListTable.tsx
@@ -171,11 +171,16 @@ type SortFunctionParams = {
 
 function sortFunction(params: SortFunctionParams): TransferReferenceQuery[] {
 	const { list, headers, tab, reverse } = params;
-	// Guard against null/malformed entries coming from the API; any of the
-	// comparators below (b.created, a.from, a.to, a.reference, b.amount) will
-	// throw on a null element and crash the whole page via the Next.js error
-	// boundary ("a client-side exception has occurred").
-	let sortingList = list.filter((i): i is TransferReferenceQuery => i != null); // writeable + null-safe
+	// Guard against null/malformed entries coming from the API. The comparators
+	// below (b.created, a.from, a.to, a.reference, b.amount) and the row renderer
+	// (item.txHash, item.chainId, item.targetChain, ...) all dereference fields
+	// directly, so a null OR an incomplete placeholder entry (e.g. the
+	// { __typename, count } row the API sometimes emits) crashes the whole page
+	// via the Next.js error boundary. Require the fields we actually use.
+	let sortingList = list.filter(
+		(i): i is TransferReferenceQuery =>
+			i != null && i.created != null && i.txHash != null && i.from != null && i.to != null && i.amount != null
+	); // writeable + null/placeholder-safe
 
 	if (tab === headers[0]) {
 		// Date

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -9,12 +9,17 @@ export const AppUrl = (url: string) => {
 };
 
 export const ContractUrl = (address: string, chain: SupportedChain = SupportedChains["mainnet"]) => {
-	const explorerLink = chain?.blockExplorers?.default.url || "https://etherscan.io/";
+	const explorerLink = chain?.blockExplorers?.default?.url || "https://etherscan.io/";
+	// path.join throws "Path must be a string. Received undefined" if address is
+	// missing (e.g. a malformed API row), which would crash the whole page.
+	if (!address) return explorerLink;
 	return path.join(explorerLink, "address", address);
 };
 
 export const TxUrl = (hash: Hash, chain: SupportedChain = SupportedChains["mainnet"]) => {
-	const explorerLink = chain?.blockExplorers?.default.url || "https://etherscan.io/";
+	const explorerLink = chain?.blockExplorers?.default?.url || "https://etherscan.io/";
+	// Guard against undefined hash for the same reason as ContractUrl above.
+	if (!hash) return explorerLink;
 	return path.join(explorerLink, "tx", hash);
 };
 


### PR DESCRIPTION
## Summary

Follow-up to #412. After null entries were filtered, `/transfer` **still crashes** with a different error:

```
TypeError: Path must be a string. Received undefined
    at path.join
    at Object.join
    at TxUrl / ContractUrl (utils/helpers.ts)
    at TransferListRow render
```

## Root cause

The API (`/transfer/reference/list`) also emits a **non-null placeholder row**:

```json
{ "__typename": "TransferReference", "count": "TransferReference" }
```

It has no `txHash`/`from`/`to`/`amount`, so it **survives the null filter** from #412. Then `TransferListRow` calls `TxUrl(item.txHash, ...)` with `txHash === undefined`, and `path.join(explorerLink, "tx", undefined)` throws — taking down the whole page again.

## Fix (two layers)

**1. `TransferListTable` — filter on the fields rows actually use.**
Require `created`, `txHash`, `from`, `to`, `amount`, so placeholder/partial rows are dropped, not just `null`.

> Verified against the **live API**: drops exactly the 3 bad entries (`{__typename, count}` + 2 nulls) and keeps all **1001 valid transfers**.

**2. `helpers.ts` — harden the URL builders (defense-in-depth).**
`TxUrl`/`ContractUrl` now return the explorer base when `hash`/`address` is undefined instead of calling `path.join` with `undefined`. Also optional-chained `blockExplorers.default?.url`. This ensures a single malformed field can never crash the page in future.

## Verification
- `yarn build` — clean production build, `/transfer` compiles
- `prettier --check` — clean
- Live-data filter check — 1004 → 1001, drops only the malformed rows

## Backend follow-up (unchanged, still recommended)
The real cause is the API/indexer emitting the null + `{__typename, count}` placeholder rows in `/transfer/reference/list`. The API should filter incomplete entries (require `txHash`, `created`) and fix the `count: "TransferReference"` mis-mapping (looks like GraphQL metadata leaking into the array).
